### PR TITLE
fix: improve logging

### DIFF
--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.2"},
+  {vsn, "1.5.3"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,6 +1,9 @@
 %% -*-: erlang -*-
-{"1.5.2",
+{"1.5.3",
   [
+    {"1.5.2",
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     ]},
     {<<"1\\.5\\..+">>,
       [ {load_module, wolff, brutal_purge, soft_purge, []}
       , {load_module, wolff_producer, brutal_purge, soft_purge, []}


### PR DESCRIPTION
Kafka leader disconnection is quite common,
logging each and every failure at error level triggers
unnecessary concnerns.

The connection pid down logs are now at info level.
Added a new error-level log after each 10 failed attempts