### PR TITLE
fix: no badarg error log when closing dead connection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 * 1.5.5
+  - Fix: fix badarg pid monitoring error log when trying to close a dead connection. (PR #20)
   - Enhance: expose wolff_client:check_connectivity/2 for connectivity check before starting a client. (PR #18)
   - Fix: better error logs (PR #16, PR #17)
     * No need to report stacktrace for timeout and connection refused errors.


### PR DESCRIPTION
this is only an unnecessary error log without any business impact
since the async close call is done in a un-linked process