### PR TITLE
fix: no crash when error code in partition metata data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 * 1.5.7
   - Stop supervised producer if failed to start. Otherwise the caller may have to call the wolff:stop_and_delete_supervised_producers/3
-    after matching an error return. If they don't, then it may appear as a resource leak.
+    after matching an error return. If they don't, then it may appear as a resource leak. [#26](https://github.com/kafka4beam/wolff/pull/26)
+  - Ensure `{{Topic, Partitio}, Connection}` record exists even if there are errors returned at partition level metadata.
+    Fixed in PR [#28](https://github.com/kafka4beam/wolff/pull/28).
+    There were two issues before this fix:
+    * `wolff_client` may crash when trying to find partition leader connection for a producer worker.
+      When there is error code in partition metadata, the connection record is not added,
+      causing a `badmatch` error in this expression `{_, MaybePid} = lists:keyfind(Partition, 1, Partitions)`.
+    * `wolff_producers` may crash when fewer partitions found in partition counter refresh.
+      Although Kakfa does not support topic down-scale, the assertion has been removed.
 * 1.5.6
   - New producer option 'drop\_if\_highmem' to limit the growth of replayq(in mem) size
   - Drop otp22 support

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,34 @@ services:
     ports:
       - "2181:2181"
     container_name: wolff-zk
-  kafka:
+  kafka_1:
+    depends_on:
+      - zookeeper
     image: wurstmeister/kafka:2.13-2.7.0
     ports:
       - "9092:9092"
-    container_name: wolff-kafka
+    container_name: wolff-kafka-1
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: DEFAULT://:9092,INTRA://:9093
+      KAFKA_ADVERTISED_LISTENERS: DEFAULT://localhost:9092,INTRA://wolff-kafka-1:9093,
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: DEFAULT:PLAINTEXT,INTRA:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTRA
       KAFKA_CREATE_TOPICS: test-topic:1:1,test-topic-2:2:1,test-topic-3:1:1,
+  kafka_2:
+    depends_on:
+      - kafka_1
+    image: wurstmeister/kafka:2.13-2.7.0
+    ports:
+      - "9192:9092"
+    container_name: wolff-kafka-2
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: DEFAULT://:9092,INTRA://:9093
+      KAFKA_ADVERTISED_LISTENERS: DEFAULT://localhost:9192,INTRA://wolff-kafka-2:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: DEFAULT:PLAINTEXT,INTRA:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTRA
+      KAFKA_CREATE_TOPICS: test-topic-r2:1:2
 

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -4,6 +4,8 @@
     {"1.5.6",
      [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers_sup, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producer, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.[2-5]">>,
      [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
@@ -25,6 +27,8 @@
     {"1.5.6",
      [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers_sup, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producer, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.[2-5]">>,
      [ {load_module, wolff_producers, brutal_purge, soft_purge, []}

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -487,11 +487,11 @@ log_connection_down(_Topic, _Partition, _, to_be_discovered) ->
   %% this is the initial state of the connection
   ok;
 log_connection_down(Topic, Partition, Conn, Reason) when is_pid(Conn) ->
-  log_info(Topic, Partition, "connection to partition leader is down, pid=~p, reason=~0p", [Conn, Reason]);
+  log_info(Topic, Partition, "connection to partition leader is down, pid=~p~nreason=~0p", [Conn, Reason]);
 log_connection_down(Topic, Partition, _, noproc) ->
   log_info(Topic, Partition, "connection to partition leader is down, pending on reconnect", []);
 log_connection_down(Topic, Partition, _, Reason) ->
-  log_info(Topic, Partition, "connection to partition leader is down, reason=~p", [Reason]).
+  log_info(Topic, Partition, "connection to partition leader is down~nreason=~p", [Reason]).
 
 ensure_delayed_reconnect(#{config := #{reconnect_delay_ms := Delay0},
                            client_id := ClientId,

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -5,7 +5,7 @@ set -eu
 docker-compose up -d
 
 n=0
-while ! docker exec wolff-kafka bash -c '/opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper --list' | grep 'test-topic'; do
+while ! docker exec wolff-kafka-2 bash -c '/opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper --list' | grep 'test-topic'; do
   if [ $n -gt 10 ]; then
     echo "timeout waiting for kafka"
     exit 1

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -299,6 +299,6 @@ ensure_partitions(Topic, Partitions) ->
 kafka_topic_cmd_base(Topic) when is_binary(Topic) ->
     kafka_topic_cmd_base(binary_to_list(Topic));
 kafka_topic_cmd_base(Topic) ->
-    "docker exec wolff-kafka /opt/kafka/bin/kafka-topics.sh" ++
+    "docker exec wolff-kafka-1 /opt/kafka/bin/kafka-topics.sh" ++
     " --zookeeper zookeeper:2181" ++
     " --topic '" ++ Topic ++ "'".


### PR DESCRIPTION
When partition leader connections are not initialized
due e.g. error in metata response, it might happen that
This crash may happen:
{{badmatch,false},[{wolff_client,handle_cast,2,[{file,"wolff_client.erl"},{line,153}
i.e. lists:keyfind returns false when the partition leader
connection does not exist even after ensure_leader_connections

This PR fixes the crash, also removes the per-partition warning
log which can be excessive.