### PR TITLE
chore: upgrade kafka_protocol from 4.0.3 to 4.1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 1.6.5
+  - Upgrade `kafka_protocol` from version 4.0.3 to version to 4.1.0 for SASL/GSSAPI auth support.
 * 1.6.4 (merged from 1.5.8)
   - Fix type specs for producers and producer config. [#31](https://github.com/kafka4beam/wolff/pull/31)
 * 1.6.3 (merged from 1.5.7)

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [ {kafka_protocol, "4.0.3"}
+{deps, [ {kafka_protocol, "4.1.0"}
        , {replayq, "0.3.4"}
        , {lc, "0.3.2"}
        ]}.

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.6.4"},
+  {vsn, "1.6.5"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,6 +1,9 @@
 %% -*-: erlang -*-
-{"1.6.4",
+{"1.6.5",
   [
+    {<<"1.6.4">>,
+     [ %% no code change
+     ]},
     {<<"1\\.6\\.[2-3]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}
@@ -15,6 +18,9 @@
     {<<".*">>, []}
   ],
   [
+    {<<"1.6.4">>,
+     [ %% no code change
+     ]},
     {<<"1\\.6\\.[2-3]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}


### PR DESCRIPTION
To support SASL/GSSAPI auth.

NOTE: kafka_protocol upgrade from 4.0.3 to 4.1.0 has no support for appup, but there is so far no such requirement.