### PR TITLE
Upgrade kafka protocol from 2.3.6.1 to 2.3.6.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
-{deps, [{kafka_protocol, {git, "https://github.com/emqx/kafka_protocol", {tag, "2.3.6.1"}}},
+{deps, [{kafka_protocol, {git, "https://github.com/emqx/kafka_protocol", {tag, "2.3.6.4"}}},
         {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.4"}}},
-        {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.2.0"}}}
+        {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}}
        ]}.
 
 {erl_opts, [ error
@@ -18,3 +18,5 @@
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                deprecated_functions]}.
+
+{shell, [{apps, [wolff]}]}.

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -509,11 +509,12 @@ ensure_delayed_reconnect(#{config := #{reconnect_delay_ms := Delay0},
                            client_id := ClientId,
                            topic := Topic,
                            partition := Partition,
-                           reconnect_timer := ?no_timer
+                           reconnect_timer := ?no_timer,
+                           conn := Conn
                           } = St, DelayStrategy) ->
   Attempts = maps:get(reconnect_attempts, St, 0),
   Attempts > 0 andalso Attempts rem 10 =:= 0 andalso
-    log_error(Topic, Partition, "still disconnected after ~p reconnect attempts", [Attempts]),
+    log_error(Topic, Partition, "still disconnected after ~p reconnect attempts, conn=~p~n", [Attempts, Conn]),
   Delay =
     case DelayStrategy of
       no_delay_for_first_attempt when Attempts =:= 0 ->


### PR DESCRIPTION
## upgrade to kafka protocol 2.3.6.4 for below changes:
1. backport fixes from later versions
2. possibility to enable sasl kerberos auth
3. fix crypto:hmac/3 for otp 24
4. add more reason code to kafka_protocol schema and fixed crashing on decoding unknown error code

## an error log message improvement
example logs:
```
=ERROR REPORT==== 21-Sep-2022::21:35:18.402381 ===
test-topic-2-0: still disconnected after 10 reconnect attempts, conn=leader_not_available
=INFO REPORT==== 21-Sep-2022::21:35:20.459241 ===
test-topic-2-0: connection to partition leader is down
reason=leader_not_available
```