### PR TITLE
fix(producers): wrong bound variables in pattern (1.5)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
-* 1.5.8
+* 1.5.9
+  - Fix: when picking a producer PID, if it was dead, it could lead to an error being raised. [#38](https://github.com/kafka4beam/wolff/pull/38)
+  * 1.5.8
   - Fix type specs for producers and producer config. [#31](https://github.com/kafka4beam/wolff/pull/31)
 * 1.5.7
   - Stop supervised producer if failed to start. Otherwise the caller may have to call the wolff:stop_and_delete_supervised_producers/3
@@ -31,4 +33,3 @@
   - Started using github action for CI
 * 1.5.1
   - Fix: connection DOWN reason. Should not be a pid, otherwise a producer may not attempt to reconnect.
-

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.8"},
+  {vsn, "1.5.9"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,6 +1,9 @@
 %% -*-: erlang -*-
-{"1.5.8",
+{"1.5.9",
   [
+    {"1.5.8",
+     [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     ]},
     {<<"1\\.5\\.[2-7]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}
@@ -19,6 +22,9 @@
     }
   ],
   [
+    {"1.5.8",
+     [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     ]},
     {<<"1\\.5\\.[2-7]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -139,18 +139,18 @@ pick_producer(#{workers := Workers,
   Partition = pick_partition(Count, Partitioner, Batch),
   do_pick_producer(Partitioner, Partition, Count, Workers).
 
-do_pick_producer(Partitioner, Partition, Count, Workers) ->
-  Pid = lookup_producer(Workers, Partition),
-  case is_pid(Pid) andalso is_process_alive(Pid) of
-    true -> {Partition, Pid};
+do_pick_producer(Partitioner, Partition0, Count, Workers) ->
+  Pid0 = lookup_producer(Workers, Partition0),
+  case is_pid(Pid0) andalso is_process_alive(Pid0) of
+    true -> {Partition0, Pid0};
     false when Partitioner =:= random ->
-      pick_next_alive(Workers, Partition, Count);
+      pick_next_alive(Workers, Partition0, Count);
     false when Partitioner =:= roundrobin ->
-      R = {Partition, Pid} = pick_next_alive(Workers, Partition, Count),
-      _ = put(wolff_roundrobin, (Partition + 1) rem Count),
+      R = {Partition1, _Pid1} = pick_next_alive(Workers, Partition0, Count),
+      _ = put(wolff_roundrobin, (Partition1 + 1) rem Count),
       R;
     false ->
-      erlang:error({producer_down, Pid})
+      erlang:error({producer_down, Pid0})
   end.
 
 pick_next_alive(Workers, Partition, Count) ->


### PR DESCRIPTION
Port of https://github.com/kafka4beam/wolff/pull/37

If a certain producer PID is dead, `pick_next_alive` will (hopefully) return a different PID and partition number.  By binding the old PID and partition number in the pattern, it'll most certainly blow up in this case.