### PR TITLE
feat: fetch messages from ETS tables

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {deps, [{kafka_protocol, {git, "https://github.com/emqx/kafka_protocol", {tag, "2.3.6.4"}}},
         {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.4"}}},
+        {msg_batcher, {git, "https://github.com/terry-xiaoyu/msg_batcher", {branch, "main"}}},
         {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}}
        ]}.
 

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.9"},
+  {vsn, "1.5.10"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -6,7 +6,8 @@
    [kernel,
     stdlib,
     kafka_protocol,
-    replayq
+    replayq,
+    msg_batcher
    ]},
   {env,[]},
   {mod, {wolff_app, start}},

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,8 +1,12 @@
 %% -*-: erlang -*-
-{"1.5.9",
+{"1.5.10",
   [
+    {"1.5.9",
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     ]},
     {"1.5.8",
-     [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producers, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.[2-7]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}
@@ -22,8 +26,12 @@
     }
   ],
   [
+    {"1.5.9",
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     ]},
     {"1.5.8",
-     [ {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producers, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.[2-7]">>,
      [ {load_module, wolff, brutal_purge, soft_purge, []}

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -427,6 +427,7 @@ tr_reason({{Host, Port}, Reason}) ->
     {bin([bin(Host), ":", bin(Port)]), do_tr_reason(Reason)}.
 
 do_tr_reason({timeout, _Stack}) -> connection_timed_out;
+do_tr_reason({{_KproReq, timeout}, _Stack}) -> connection_timed_out;
 do_tr_reason({enetunreach, _Stack}) -> unreachable_host;
 do_tr_reason({econnrefused, _Stack}) -> connection_refused;
 do_tr_reason({nxdomain, _Stack}) -> unresolvable_hostname;

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -507,7 +507,7 @@ handle_kafka_ack(#kpro_rsp{api = produce,
       do_handle_kafka_ack(Ref, BaseOffset, St);
     false ->
       #{topic := Topic, partition := Partition} = St,
-      log_warn(Topic, Partition, "~s-~p: Produce response error-code = ~0p", [ErrorCode]),
+      log_warn(Topic, Partition, "Produce response error-code = ~0p", [ErrorCode]),
       erlang:throw(ErrorCode)
   end.
 

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -323,7 +323,7 @@ make_call_id(Base) ->
 use_defaults(Config) ->
   use_defaults(Config, [{required_acks, all_isr},
                         {ack_timeout, 10000},
-                        {max_batch_count, 500},
+                        {max_batch_count, 1},
                         {max_batch_interval, 50},
                         {max_batch_bytes, ?WOLFF_KAFKA_DEFAULT_MAX_MESSAGE_BYTES},
                         {max_linger_ms, 0},

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -144,8 +144,8 @@ send(Pid, [_ | _] = Batch0, AckFun) ->
     _ ->
       case msg_batcher:enqueue(Pid, ?SEND_REQ(?no_queued_reply, Batch, AckFun)) of
         ok -> ok;
-        {error, batcher_not_found} ->
-          erlang:throw(producer_down)
+        {error, Reason} ->
+          erlang:throw({produce_error, Reason})
       end
   end.
 
@@ -187,8 +187,8 @@ send_sync(Pid, Batch0, Timeout) ->
             Timeout ->
               erlang:error(timeout)
           end;
-        {error, batcher_not_found} ->
-          erlang:throw(producer_down)
+        {error, Reason} ->
+          erlang:throw({produce_error, Reason})
       end
   end.
 

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -170,7 +170,7 @@ stop_with_name_test() ->
   ok.
 
 partition_count_refresh_test_() ->
-  {timeout, 30, %% it takes time to alter topic via cli in docker container
+  {timeout, 120, %% it takes time to alter topic via cli in docker container
    fun test_partition_count_refresh/0}.
 
 test_partition_count_refresh() ->


### PR DESCRIPTION
This PR is converted to draft as the ETS batcher is not production ready yet.

Created a blog: https://emqx.atlassian.net/wiki/spaces/~7012105c2b79a66fb4fb0a8de5cf959517d4a/blog/2023/07/13/654606795/Improve+the+performance+of+Kafka+producers+using+ETS+batcher
