### PR TITLE
fix(client): fix connection error reason translation

### DIFF
--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.11"},
+  {vsn, "1.5.12"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,6 +1,9 @@
-%% -*-: erlang -*-
-{"1.5.11",
+%% -*- mode: erlang -*-
+{"1.5.12",
   [
+   {"1.5.11",
+     [ {load_module, wolff_client, brutal_purge, soft_purge, []}
+     ]},
     {"1.5.10",
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}
@@ -34,6 +37,9 @@
     }
   ],
   [
+    {"1.5.11",
+      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
+      ]},
     {"1.5.10",
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -426,6 +426,7 @@ get_config(#{start := {_Module, _StartLink, Args}}) ->
 tr_reason({{Host, Port}, Reason}) ->
     {bin([bin(Host), ":", bin(Port)]), do_tr_reason(Reason)}.
 
+do_tr_reason({{#kpro_req{}, Reason}, Stack}) -> do_tr_reason({Reason, Stack});
 do_tr_reason({timeout, _Stack}) -> connection_timed_out;
 do_tr_reason({enetunreach, _Stack}) -> unreachable_host;
 do_tr_reason({econnrefused, _Stack}) -> connection_refused;


### PR DESCRIPTION
Before:
```
[{<<"xxx:9092">>,{{{kpro_req,#Ref<0.2279739190.1863843841.210504>,sasl_authenticate,0,false,[[<<0,0,0,83>>,<<0,77,68,51,84,...>>]]},timeout},[{kpro_lib,send_and_recv_raw,4,[{file,"kpro_lib.erl"},{line,70}]},{kpro_lib,send_and_recv,5,[{file,"kpro_lib.erl"},{line,81}]},{kpro_sasl,'-auth/7-fun-1-',5,[{file,"kpro_sasl.erl"},{line,63}]},{kpro_sasl,do_auth,3,[{file,"kpro_sasl.erl"},{line,85}]},{kpro_connection,init_connection,2,[{file,"kpro_connection.erl"},{line,245}]},{kpro_connection,init,4,[{file,"kpro_connection.erl"},{line,175}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}}]
```

After:
```
[{<<"xxx:9092">>,connection_timed_out}]
```