### PR TITLE
fix: return partition count -1 when unavailable.

### DIFF
--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -60,6 +60,7 @@
 -define(initialized, initialized).
 -define(partition_count_refresh_interval_seconds, 300).
 -define(refresh_partition_count, refresh_partition_count).
+-define(partition_count_unavailable, -1).
 
 %% @doc Called by wolff_producers_sup to start wolff_producers process.
 start_link(ClientId, Topic, Config) ->
@@ -453,8 +454,8 @@ start_new_producers(#{client_id := ClientId,
   St.
 
 get_partition_cnt(ClientId, Topic) ->
-  [{_, Count}] = ets:lookup(?WOLFF_PRODUCERS_GLOBAL_TABLE, {ClientId, Topic, partition_count}),
-  Count.
+  ets:lookup_element(?WOLFF_PRODUCERS_GLOBAL_TABLE, {ClientId, Topic, partition_count},
+                     2, ?partition_count_unavailable).
 
 put_partition_cnt(ClientId, Topic, Count) ->
   _ = ets:insert(?WOLFF_PRODUCERS_GLOBAL_TABLE, {{ClientId, Topic, partition_count}, Count}),

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -453,9 +453,20 @@ start_new_producers(#{client_id := ClientId,
   end,
   St.
 
+
+-if(OTP_RELEASE >= "26").
 get_partition_cnt(ClientId, Topic) ->
   ets:lookup_element(?WOLFF_PRODUCERS_GLOBAL_TABLE, {ClientId, Topic, partition_count},
                      2, ?partition_count_unavailable).
+-else.
+get_partition_cnt(ClientId, Topic) ->
+  try ets:lookup_element(?WOLFF_PRODUCERS_GLOBAL_TABLE, {ClientId, Topic, partition_count},
+                     2)
+  catch
+    error:badarg ->
+      ?partition_count_unavailable
+  end.
+-endif.
 
 put_partition_cnt(ClientId, Topic, Count) ->
   _ = ets:insert(?WOLFF_PRODUCERS_GLOBAL_TABLE, {{ClientId, Topic, partition_count}, Count}),


### PR DESCRIPTION
There could be a race that when caller pick producer failed due to ongoing producer restarts.

As the produce API is none blocking by design, we handle this error to set partition count to -1 and will trigger an error 
``{invalid_partition_count, -1, Partitioner}`` and expecting caller to handle this specific error with retries. 