### PR TITLE
feat: add max_partitions limit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 1.10.0
+  - Add `max_partitions` producer config to limit the number of partition producers so the client side is also possible to have control over resource utilization.
+
 * 1.9.1
   - Use ETS (named `wolff_clients_global`) for client ID registration.
     When there are thousands of clients, `supervisor:which_children` becomes quite expensive.


### PR DESCRIPTION
Add a `max_partitions` producer config.
This config makes it possible to limit resource utilization from client side, especially when Kafka topic is not in control.

For example, in a shared data export platform, an overprovisioned topic (e.g. 100000 partitions),
may cause client side to spawn the same number of partition workers despite the fact that the user only has 
very limited resource quota (e.g. 10 message/s).
