### PR TITLE
fix(wolff_client): keep metadata connection alive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+* 1.5.13
+  - Use long-lived metadata connection.
+    This is to avoid having to excessively re-establish connection when there are many concurrent connectivity checks.
+* 1.5.12
+  - Fix connection error reason translation, the error log is now more compact when e.g. connect timeout happens.
 * 1.5.11
   - Fixed a try catch pattern in `gen_server` call towards client process, this should prevent `wolff_producers` from crash if `wolff_client` is killed during initialization.
 * 1.5.10

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.12"},
+  {vsn, "1.5.13"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
-{"1.5.12",
+{"1.5.13",
   [
-   {"1.5.11",
+   {<<"1\\.5\\.1[1-2]">>,
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
      ]},
     {"1.5.10",
@@ -37,7 +37,7 @@
     }
   ],
   [
-    {"1.5.11",
+    {<<"1\\.5\\.1[1-2]">>,
       [ {load_module, wolff_client, brutal_purge, soft_purge, []}
       ]},
     {"1.5.10",


### PR DESCRIPTION
Some environments (e.g. Azure Event Hubs) appears to have a connection rate limit.
tcpdump suggested TCP SYN packet being retransmitted before the connectivity check returned error.

This PR keeps the client's metadata connection alive (instead of immediately close after usage).
And the connectivity check returns `ok` immediately if the connection process is alive.