### PR TITLE
Split batch and retry if message_too_large

### DIFF
--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.13"},
+  {vsn, "1.5.14"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,8 +1,10 @@
 %% -*- mode: erlang -*-
-{"1.5.13",
+{"1.5.14",
   [
-   {<<"1\\.5\\.1[1-2]">>,
+   {<<"1\\.5\\.1[1-3]">>,
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producer, brutal_purge, soft_purge, []}
      ]},
     {"1.5.10",
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
@@ -37,9 +39,11 @@
     }
   ],
   [
-    {<<"1\\.5\\.1[1-2]">>,
-      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
-      ]},
+    {<<"1\\.5\\.1[1-3]">>,
+     [ {load_module, wolff_client, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producers, brutal_purge, soft_purge, []}
+     , {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     ]},
     {"1.5.10",
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -41,7 +41,7 @@
 -export([get_producer/2]).
 
 -export_type([client_id/0, host/0, producers/0, msg/0, ack_fun/0, partitioner/0,
-              name/0, offset_reply/0]).
+              name/0, offset_reply/0, topic/0]).
 
 -type client_id() :: binary().
 -type host() :: kpro:endpoint().
@@ -49,7 +49,7 @@
 -type partition() :: kpro:partition().
 -type name() :: atom().
 -type offset() :: kpro:offset().
--type offset_reply() :: offset() | buffer_overflow_discarded.
+-type offset_reply() :: offset() | buffer_overflow_discarded | message_too_large.
 -type producers_cfg() :: wolff_producers:config().
 -type producers() :: wolff_producers:producers().
 -type partitioner() :: wolff_producers:partitioner().
@@ -123,6 +123,8 @@ send(Producers, Batch, AckFun) ->
 %%       the returned offset will always be `?UNKNOWN_OFFSET' (`-1').
 %%       In case the batch is discarded due to buffer overflow, the offset
 %%       is `buffer_overflow_discarded'.
+%%       In case a single message is too large (Kafka topic config max.message.bytes)
+%%       the offset is `message_too_large'.
 -spec send_sync(producers(), [msg()], timeout()) -> {partition(), offset_reply()}.
 send_sync(Producers, Batch, Timeout) ->
   {_Partition, ProducerPid} = wolff_producers:pick_producer(Producers, Batch),

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -141,7 +141,7 @@ pick_producer(#{workers := Workers,
 
 do_pick_producer(Partitioner, Partition0, Count, Workers) ->
   Pid0 = lookup_producer(Workers, Partition0),
-  case is_pid(Pid0) andalso is_process_alive(Pid0) of
+  case is_alive(Pid0) of
     true -> {Partition0, Pid0};
     false when Partitioner =:= random ->
       pick_next_alive(Workers, Partition0, Count);
@@ -150,7 +150,7 @@ do_pick_producer(Partitioner, Partition0, Count, Workers) ->
       _ = put(wolff_roundrobin, (Partition1 + 1) rem Count),
       R;
     false ->
-      erlang:error({producer_down, Pid0})
+      erlang:error({producer_down, {Workers, Partition0}})
   end.
 
 pick_next_alive(Workers, Partition, Count) ->
@@ -172,8 +172,17 @@ lookup_producer(#{workers := Workers}, Partition) ->
 lookup_producer(Workers, Partition) when is_map(Workers) ->
   maps:get(Partition, Workers);
 lookup_producer(Workers, Partition) ->
-  [{Partition, Pid}] = ets:lookup(Workers, Partition),
-  Pid.
+  try
+    case ets:lookup(Workers, Partition) of
+      [] ->
+        erlang:error({bad_produer, {Workers, Partition}});
+      [{Partition, Pid}] ->
+        Pid
+    end
+  catch
+    error:badarg ->
+      erlang:error({producer_down, {Workers, Partition}})
+  end.
 
 pick_partition(_Count, Partition, _) when is_integer(Partition) ->
   Partition;

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -24,7 +24,7 @@
 %% gen_server callbacks
 -export([code_change/3, handle_call/3, handle_cast/2, handle_info/2, init/1, terminate/2]).
 
--export_type([producers/0, config/0]).
+-export_type([producers/0, config/0, partitioner/0]).
 
 -include("wolff.hrl").
 
@@ -175,7 +175,7 @@ lookup_producer(Workers, Partition) ->
   try
     case ets:lookup(Workers, Partition) of
       [] ->
-        erlang:error({bad_produer, {Workers, Partition}});
+        erlang:error({bad_producer, {Workers, Partition}});
       [{Partition, Pid}] ->
         Pid
     end


### PR DESCRIPTION
When message_too_large is received from Kafka, the producer will:
1. If single-message is too large, drop the message, and reply error to caller, also log a `error` level message
2. For `size>=2` batches, split the batches into single-message batches, and retry, then lower the config `max_batch_bytes` to half.