### PR TITLE
refactor: remove roundrobin partitioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ wolff:send(Producers, [Msg], AckFun).
 * `compression`: `no_compression` (default) `snappy` or `gzip`.
 
 * `partitioner`: default `random`. other possible values are:
-   `roundrobin`: Starts from partition `0`, next partition to use is saved in caller's
-   process dictionary.
    `first_key_dispatch`: `erlang:phash2(Key) rem PartitionCount` where Key is the `key`
    field of the first message in the batch to produce.
    `fun((PartitionCount, [msg()]) -> partition())`: Caller defined callback.

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -227,7 +227,6 @@ test_connection_restart() ->
   ProducerCfg0 = producer_config(),
   %% allow message linger, so we have time to kill the connection
   ProducerCfg = ProducerCfg0#{max_linger_ms => 200,
-                              partitioner => roundrobin,
                               reconnect_delay_ms => 0
                              },
   {ok, Producers} = wolff:start_producers(Client, <<"test-topic">>, ProducerCfg),


### PR DESCRIPTION
roudrobin was never used, and it was implemented wrong (process dict) if needed, it should be re-implemented using an atomic