### PR TITLE
0722 dynamic topics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
     Add `#{group => <<"group1">>}` to producer config for namespacing the topic,
     so multiple producers for one topic will not clash each other when sharing the same client.
   - Support dynamic topics for supervised producers.
-    Call `wolff:ensure_supervised_producers(ClientId, _Topics=[], #{group => GroupName, ...})` to
+    Call `wolff:ensure_supervised_dynamic_producers(ClientId, #{group => GroupName, ...})` to
     start a group-producer with no topics added in advance.
     And call `wolff:send2` or `wolff:send_sync2` to publish messages with topic provided as an argument.
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
   - Change `alias` to `group`.
     Add `#{group => <<"group1">>}` to producer config for namespacing the topic,
     so multiple producers for one topic will not clash each other when sharing the same client.
+  - Support dynamic topics for supervised producers.
+    Call `wolff:ensure_supervised_producers(ClientId, _Topics=[], #{group => GroupName, ...})` to
+    start a group-producer with no topics added in advance.
+    And call `wolff:send2` or `wolff:send_sync2` to publish messages with topic provided as an argument.
 
 * 2.0.0
   - Added the `alias` producer config option to make producers to the same topic be independent.

--- a/include/wolff.hrl
+++ b/include/wolff.hrl
@@ -21,15 +21,18 @@
 %% Table to register {NS, Topic, Partition} -> Pid mapping.
 %% This allows all producers to share this one ETS table for quick
 %% partition-worker lookup.
-%% A special record {{NS, Topic, partition_count}, Count}
-%% is inserted to cache the partition count.
-%% NS is either `{client, ClientId}` for regular producers
-%% or `Group` if topic is assigned to a group.
+%% - A special record {{NS, Topic, partition_count}, Count}
+%%   is inserted to cache the partition count.
+%%   NS is either `{client, ClientId}` for regular producers
+%%   or `Group` if topic is assigned to a group.
+%% - A special record {{NS, Topic}, 'unknown?'} -> timestamp() is
+%%   inserted to cache the non-exist status of a topic.
 -define(WOLFF_PRODUCERS_GLOBAL_TABLE, wolff_producers_global).
 
 -define(NS_TOPIC(NS, TOPIC), {NS, TOPIC}).
 -define(NO_GROUP, no_group).
 -define(DYNAMIC, dynamic).
+-define(UNKNOWN, 'unknown?').
 
 -define(all_partitions, all_partitions).
 

--- a/include/wolff.hrl
+++ b/include/wolff.hrl
@@ -29,6 +29,7 @@
 
 -define(NS_TOPIC(NS, TOPIC), {NS, TOPIC}).
 -define(NO_GROUP, no_group).
+-define(DYNAMIC, dynamic).
 
 -define(all_partitions, all_partitions).
 

--- a/include/wolff.hrl
+++ b/include/wolff.hrl
@@ -25,14 +25,14 @@
 %%   is inserted to cache the partition count.
 %%   NS is either `{client, ClientId}` for regular producers
 %%   or `Group` if topic is assigned to a group.
-%% - A special record {{NS, Topic}, 'unknown?'} -> timestamp() is
-%%   inserted to cache the non-exist status of a topic.
+%% - When Count is {?UNKNOWN, Timestamp}, it means the topic
+%%   is not found in Kafka or the client is not authorized to access it
 -define(WOLFF_PRODUCERS_GLOBAL_TABLE, wolff_producers_global).
 
 -define(NS_TOPIC(NS, TOPIC), {NS, TOPIC}).
 -define(NO_GROUP, no_group).
 -define(DYNAMIC, dynamic).
--define(UNKNOWN, 'unknown?').
+-define(UNKNOWN(TS), {unknown, TS}).
 
 -define(all_partitions, all_partitions).
 

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -91,10 +91,10 @@ stop_producers(Producers) ->
   wolff_producers:stop_linked(Producers).
 
 %% @doc Ensure supervised producers are started.
--spec ensure_supervised_producers(client_id(), topic(), producers_cfg()) ->
+-spec ensure_supervised_producers(client_id(), topic() | [topic()], producers_cfg()) ->
   {ok, producers()} | {error, any()}.
-ensure_supervised_producers(ClientId, Topic, ProducerCfg) ->
-  wolff_producers:start_supervised(ClientId, Topic, ProducerCfg).
+ensure_supervised_producers(ClientId, Topics, ProducerCfg) ->
+  wolff_producers:start_supervised(ClientId, Topics, ProducerCfg).
 
 %% @doc Ensure supervised producers are stopped then deleted.
 -spec stop_and_delete_supervised_producers(wolff_producers:producers()) -> ok.

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -39,7 +39,9 @@
 
 %% Messaging APIs of dynamic producer.
 -export([send2/4,
-         send_sync2/4
+         send_sync2/4,
+         add_topic/2,
+         remove_topic/2
         ]).
 
 -export([check_connectivity/1,
@@ -153,6 +155,18 @@ send_sync(Producers, Batch, Timeout) ->
 send_sync2(Producers, Topic, Batch, Timeout) ->
   {_Partition, ProducerPid} = wolff_producers:pick_producer2(Producers, Topic, Batch),
   wolff_producer:send_sync(ProducerPid, Batch, Timeout).
+
+%% @doc Add a topic to dynamic producer.
+%% Returns `ok' if the topic is already addded.
+-spec add_topic(producers(), topic()) -> ok | {error, any()}.
+add_topic(Producers, Topic) ->
+  wolff_producers:add_topic(Producers, Topic).
+
+%% @doc Remove a topic from dynamic producer.
+%% Returns `ok' if the topic is already removed.
+-spec remove_topic(producers(), topic()) -> ok.
+remove_topic(Producers, Topic) ->
+  wolff_producers:remove_topic(Producers, Topic).
 
 %% @hidden For test only.
 get_producer(Producers, Partition) ->

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -28,6 +28,7 @@
 
 %% Supervised producer management APIs
 -export([ensure_supervised_producers/3,
+         ensure_supervised_dynamic_producers/2,
          stop_and_delete_supervised_producers/1
         ]).
 
@@ -96,10 +97,16 @@ stop_producers(Producers) ->
   wolff_producers:stop_linked(Producers).
 
 %% @doc Ensure supervised producers are started.
--spec ensure_supervised_producers(client_id(), topic() | [topic()], producers_cfg()) ->
+-spec ensure_supervised_producers(client_id(), topic(), producers_cfg()) ->
   {ok, producers()} | {error, any()}.
-ensure_supervised_producers(ClientId, Topics, ProducerCfg) ->
-  wolff_producers:start_supervised(ClientId, Topics, ProducerCfg).
+ensure_supervised_producers(ClientId, Topic, ProducerCfg) ->
+  wolff_producers:start_supervised(ClientId, Topic, ProducerCfg).
+
+%% @doc Ensure supervised dynamic-producers are started.
+-spec ensure_supervised_dynamic_producers(client_id(), producers_cfg()) ->
+  {ok, producers()} | {error, any()}.
+ensure_supervised_dynamic_producers(ClientId, ProducerCfg) ->
+  wolff_producers:start_supervised_dynamic(ClientId, ProducerCfg).
 
 %% @doc Ensure supervised producers are stopped then deleted.
 -spec stop_and_delete_supervised_producers(wolff_producers:producers()) -> ok.

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -124,7 +124,6 @@ send(Producers, Batch, AckFun) ->
 %% @doc Topic as argument for dynamic producers, otherwise equivalent to `send/3'.
 -spec send2(producers(), topic(), [msg()], ack_fun()) -> {partition(), pid()}.
 send2(Producers, Topic, Batch, AckFun) ->
-  ok = wolff_producers:ensure_topic(Producers, Topic),
   {Partition, ProducerPid} = wolff_producers:pick_producer2(Producers, Topic, Batch),
   ok = wolff_producer:send(ProducerPid, Batch, AckFun),
   {Partition, ProducerPid}.
@@ -145,7 +144,6 @@ send_sync(Producers, Batch, Timeout) ->
 %% @doc Topic as argument for dynamic producers, otherwise equivalent to `send_sync/3'.
 -spec send_sync2(producers(), topic(), [msg()], timeout()) -> {partition(), offset_reply()}.
 send_sync2(Producers, Topic, Batch, Timeout) ->
-  ok = wolff_producers:ensure_topic(Producers, Topic),
   {_Partition, ProducerPid} = wolff_producers:pick_producer2(Producers, Topic, Batch),
   wolff_producer:send_sync(ProducerPid, Batch, Timeout).
 

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -370,6 +370,12 @@ ensure_leader_connections2(#{conn_config := ConnConfig,
   case get_metadata(SeedHosts, ConnConfig, Topic, []) of
     {ok, {ConnPid, {Brokers, PartitionMetaList}}} ->
       ensure_leader_connections3(St, Group, Topic, ConnPid, Brokers, PartitionMetaList, MaxPartitions);
+    {error, unknown_topic_or_partition} ->
+      log_warn(failed_to_fetch_metadata,
+               #{topic => Topic,
+                 description => "The topic does not exist, or client is not authorized to access"
+                }),
+      {error, unknown_topic_or_partition};
     {error, Errors} ->
       log_warn(failed_to_fetch_metadata, #{topic => Topic, errors => Errors}),
       {error, failed_to_fetch_metadata}

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -201,7 +201,7 @@ stop_supervised(ClientId, ?NS_TOPIC(NS, Topic) = ID) ->
           _ when is_binary(NS) ->
             NS
        end,
-       ok = wolff_client:delete_producers_metadata(Pid, Group, Topic);
+       ok = wolff_client:release_leader_conns(Pid, Group, Topic);
     {error, _} ->
        %% not running
        ok

--- a/src/wolff_producers_sup.erl
+++ b/src/wolff_producers_sup.erl
@@ -19,6 +19,7 @@
 -export([start_link/0, init/1]).
 
 -export([ensure_present/3, ensure_absence/1]).
+-export([get_producers_pid/1]).
 
 -define(SUPERVISOR, ?MODULE).
 
@@ -61,3 +62,16 @@ child_spec(ClientId, ProducerId, Config) ->
     restart => transient,
     type => worker
    }.
+
+%% Find the running process (gen_server of wolff_producers) from thie child ID.
+get_producers_pid(ID) ->
+  Children = supervisor:which_children(?SUPERVISOR),
+  case lists:keyfind(ID, 1, Children) of
+    {ID, Pid, _Type, _Modules} when is_pid(Pid) ->
+      Pid;
+    Other ->
+      throw(#{cause => producers_not_found_uder_supervisor,
+              child_id => ID,
+              lookup_result => Other
+             })
+  end.

--- a/src/wolff_producers_sup.erl
+++ b/src/wolff_producers_sup.erl
@@ -70,7 +70,7 @@ get_producers_pid(ID) ->
     {ID, Pid, _Type, _Modules} when is_pid(Pid) ->
       Pid;
     Other ->
-      throw(#{cause => producers_not_found_uder_supervisor,
+      throw(#{cause => producers_not_found_under_supervisor,
               child_id => ID,
               lookup_result => Other
              })

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -39,6 +39,8 @@ dynamic_topics_test() ->
                 }, sys:get_state(ClientPid)),
   %% We now stop one of the producers.  The other should keep working.
   ok = wolff:stop_and_delete_supervised_producers(Producers),
+  %% idempotent
+  ok = wolff:stop_and_delete_supervised_producers(Producers),
   ?assertMatch(#{known_topics := Topics,
                  conns := Conns
                 } when map_size(Topics) =:= 0 andalso map_size(Conns) =:= 0,
@@ -95,6 +97,12 @@ unknown_topic_expire_test() ->
   ok = wolff:stop_and_delete_supervised_client(ClientId),
   ok = application:stop(wolff),
   ok = delete_topic(Topic).
+
+bad_producers_test() ->
+  Producers = #{group => ?NO_GROUP, client_id => <<"foobar">>, topics => <<"test-topic">>},
+  Msg = #{value => <<"v">>},
+  ?assertError("cannot_add_topic_to_non_dynamic_producer", wolff:send_sync2(Producers, <<"test-topic">>, [Msg], 1000)),
+  ok.
 
 %% helpers
 

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -43,12 +43,58 @@ dynamic_topics_test() ->
                  conns := Conns
                 } when map_size(Topics) =:= 0 andalso map_size(Conns) =:= 0,
                sys:get_state(ClientPid)),
+  ?assertEqual([], ets:tab2list(?WOLFF_PRODUCERS_GLOBAL_TABLE)),
   ok = wolff:stop_and_delete_supervised_client(ClientId),
   ok = application:stop(wolff),
   ok.
 
 unknown_topic_expire_test() ->
-  ok.
+  _ = application:stop(wolff), %% ensure stopped
+  {ok, _} = application:ensure_all_started(wolff),
+  ClientId = <<"dynamic-topics">>,
+  ClientCfg = client_config(),
+  {ok, _ClientPid} = wolff:ensure_supervised_client(ClientId, ?HOSTS, ClientCfg),
+  Group = atom_to_binary(?FUNCTION_NAME),
+  ProducerCfg = #{required_acks => all_isr,
+                  group => Group,
+                  partitioner => 0
+                 },
+  {ok, Producers} = wolff:ensure_supervised_producers(ClientId, [], ProducerCfg),
+  ?assertEqual({ok, Producers}, wolff:ensure_supervised_producers(ClientId, [], ProducerCfg)),
+  Children = supervisor:which_children(wolff_producers_sup),
+  ?assertMatch([_], Children),
+  %% We can send from each producer.
+  Msg = #{key => ?KEY, value => <<"value">>},
+  Self = self(),
+  AckFun = fun(_Partition, _BaseOffset) -> Self ! acked, ok end,
+  Ts0 = erlang:system_time(millisecond),
+  Topic = iolist_to_binary([<<"tmp_topic_">>, integer_to_list(Ts0)]),
+  ?assertThrow(#{cause := unknown_topic_or_partition,
+                 group := Group,
+                 topic := Topic,
+                 response := received
+                }, wolff:send2(Producers, Topic, [Msg], AckFun)),
+  [{{Group, Topic, ?UNKNOWN}, Ts1}] = ets:tab2list(?WOLFF_PRODUCERS_GLOBAL_TABLE),
+  %% try to send again, should not result in a new ts
+  ?assertThrow(#{cause := unknown_topic_or_partition,
+                 group := Group,
+                 topic := Topic,
+                 response := cached
+                }, wolff:send2(Producers, Topic, [Msg], AckFun)),
+  ?assertEqual([{{Group, Topic, ?UNKNOWN}, Ts1}], ets:tab2list(?WOLFF_PRODUCERS_GLOBAL_TABLE)),
+  %% force the unknown mark to expire
+  ets:insert(?WOLFF_PRODUCERS_GLOBAL_TABLE, {{Group, Topic, ?UNKNOWN}, Ts1 - timer:seconds(31)}),
+  %% create the topic in Kafka
+  ok = create_topic(Topic),
+  ?assertMatch({0, Offset} when is_integer(Offset),
+               wolff:send_sync2(Producers, Topic, [Msg], 10_000)),
+  ?assertEqual([], ets:lookup(?WOLFF_PRODUCERS_GLOBAL_TABLE, {Group, Topic, ?UNKNOWN})),
+  %% cleanup
+  ok = wolff:stop_and_delete_supervised_producers(Producers),
+  ?assertEqual([], ets:tab2list(?WOLFF_PRODUCERS_GLOBAL_TABLE)),
+  ok = wolff:stop_and_delete_supervised_client(ClientId),
+  ok = application:stop(wolff),
+  ok = delete_topic(Topic).
 
 %% helpers
 
@@ -56,3 +102,24 @@ client_config() -> #{}.
 
 key(Name) ->
   iolist_to_binary(io_lib:format("~0p/~0p/~0p", [Name, calendar:local_time(), erlang:system_time()])).
+
+create_topic(Topic) when is_binary(Topic) ->
+  create_topic(binary_to_list(Topic));
+create_topic(Topic) ->
+  Cmd = kafka_topic_cmd_base(Topic) ++ " --create --partitions 1 --replication-factor 1",
+  Result = os:cmd(Cmd),
+  Pattern = "Created topic " ++ Topic ++ ".",
+  ?assert(string:str(Result, Pattern) > 0),
+  ok.
+
+delete_topic(Topic) when is_binary(Topic) ->
+  delete_topic(binary_to_list(Topic));
+delete_topic(Topic) ->
+  Cmd = kafka_topic_cmd_base(Topic) ++ " --delete",
+  _ = os:cmd(Cmd),
+  ok.
+
+kafka_topic_cmd_base(Topic) ->
+  "docker exec wolff-kafka-1 /opt/kafka/bin/kafka-topics.sh" ++
+  " --zookeeper zookeeper:2181" ++
+  " --topic '" ++ Topic ++ "'".

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -19,8 +19,8 @@ dynamic_topics_test() ->
                   group => Group,
                   partitioner => 0
                  },
-  {ok, Producers} = wolff:ensure_supervised_producers(ClientId, [], ProducerCfg),
-  ?assertEqual({ok, Producers}, wolff:ensure_supervised_producers(ClientId, [], ProducerCfg)),
+  {ok, Producers} = start(ClientId, ProducerCfg),
+  ?assertEqual({ok, Producers}, start(ClientId, ProducerCfg)),
   Children = supervisor:which_children(wolff_producers_sup),
   ?assertMatch([_], Children),
   %% We can send from each producer.
@@ -61,8 +61,7 @@ unknown_topic_expire_test() ->
                   group => Group,
                   partitioner => 0
                  },
-  {ok, Producers} = wolff:ensure_supervised_producers(ClientId, [], ProducerCfg),
-  ?assertEqual({ok, Producers}, wolff:ensure_supervised_producers(ClientId, [], ProducerCfg)),
+  {ok, Producers} = start(ClientId, ProducerCfg),
   Children = supervisor:which_children(wolff_producers_sup),
   ?assertMatch([_], Children),
   %% We can send from each producer.
@@ -131,3 +130,6 @@ kafka_topic_cmd_base(Topic) ->
   "docker exec wolff-kafka-1 /opt/kafka/bin/kafka-topics.sh" ++
   " --zookeeper zookeeper:2181" ++
   " --topic '" ++ Topic ++ "'".
+
+start(ClientId, ProducerCfg) ->
+  wolff:ensure_supervised_dynamic_producers(ClientId, ProducerCfg).

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -1,0 +1,59 @@
+-module(wolff_dynamic_topics_tests).
+
+-include("wolff.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kafka_protocol/include/kpro.hrl").
+
+-define(KEY, key(?FUNCTION_NAME)).
+-define(HOSTS, [{"localhost", 9092}]).
+
+%% Checks that having different producers to the same kafka topic works.
+dynamic_topics_test() ->
+  _ = application:stop(wolff), %% ensure stopped
+  {ok, _} = application:ensure_all_started(wolff),
+  ClientId = <<"dynamic-topics">>,
+  ClientCfg = client_config(),
+  {ok, ClientPid} = wolff:ensure_supervised_client(ClientId, ?HOSTS, ClientCfg),
+  Group = atom_to_binary(?FUNCTION_NAME),
+  ProducerCfg = #{required_acks => all_isr,
+                  group => Group,
+                  partitioner => 0
+                 },
+  {ok, Producers} = wolff:ensure_supervised_producers(ClientId, [], ProducerCfg),
+  ?assertEqual({ok, Producers}, wolff:ensure_supervised_producers(ClientId, [], ProducerCfg)),
+  Children = supervisor:which_children(wolff_producers_sup),
+  ?assertMatch([_], Children),
+  %% We can send from each producer.
+  Msg = #{key => ?KEY, value => <<"value">>},
+  Self = self(),
+  AckFun = fun(_Partition, _BaseOffset) -> Self ! acked, ok end,
+  T1 = <<"test-topic">>,
+  T2 = <<"test-topic-2">>,
+  T3 = <<"test-topic-3">>,
+  ?assertMatch({0, Pid} when is_pid(Pid), wolff:send2(Producers, T1, [Msg], AckFun)),
+  receive acked -> ok end,
+  ?assertMatch({0, Offset} when is_integer(Offset), wolff:send_sync2(Producers, T2, [Msg], 10_000)),
+  ?assertMatch({0, Offset} when is_integer(Offset), wolff:send_sync2(Producers, T3, [Msg], 10_000)),
+  ?assertMatch(#{known_topics := #{T1 := _, T2 := _, T3 := _},
+                 conns := #{{T1, 0} := _, {T2, 0} := _, {T3, 0} := _}
+                }, sys:get_state(ClientPid)),
+  %% We now stop one of the producers.  The other should keep working.
+  ok = wolff:stop_and_delete_supervised_producers(Producers),
+  ?assertMatch(#{known_topics := Topics,
+                 conns := Conns
+                } when map_size(Topics) =:= 0 andalso map_size(Conns) =:= 0,
+               sys:get_state(ClientPid)),
+  ok = wolff:stop_and_delete_supervised_client(ClientId),
+  ok = application:stop(wolff),
+  ok.
+
+unknown_topic_expire_test() ->
+    ok.
+
+%% helpers
+
+client_config() -> #{}.
+
+key(Name) ->
+  iolist_to_binary(io_lib:format("~p/~p/~p", [Name, calendar:local_time(),
+                                              erlang:system_time()])).

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -48,12 +48,11 @@ dynamic_topics_test() ->
   ok.
 
 unknown_topic_expire_test() ->
-    ok.
+  ok.
 
 %% helpers
 
 client_config() -> #{}.
 
 key(Name) ->
-  iolist_to_binary(io_lib:format("~p/~p/~p", [Name, calendar:local_time(),
-                                              erlang:system_time()])).
+  iolist_to_binary(io_lib:format("~0p/~0p/~0p", [Name, calendar:local_time(), erlang:system_time()])).

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -82,7 +82,7 @@ different_producers_same_topic_test() ->
   {ok, _} = application:ensure_all_started(wolff),
   ClientId = <<"same-topic">>,
   ClientCfg = client_config(),
-  {ok, _ClientPid} = wolff:ensure_supervised_client(ClientId, ?HOSTS, ClientCfg),
+  {ok, ClientPid} = wolff:ensure_supervised_client(ClientId, ?HOSTS, ClientCfg),
   Topic = <<"test-topic">>,
   ProducerName0 = <<"p0">>,
   Group0 = <<"a0">>,
@@ -113,6 +113,9 @@ different_producers_same_topic_test() ->
                          filelib:is_dir(filename:join([BaseDir, File])),
                          lists:member(list_to_binary(File), [Dir0, Dir1])],
   ?assertMatch([_, _], ReplayQDirs, #{base_dir => Files}),
+  ?assertMatch(#{known_topics := #{Topic := #{Group0 := true, Group1 := true}},
+                 conns := #{{Topic, 0} := _}
+                }, sys:get_state(ClientPid)),
   %% We now stop one of the producers.  The other should keep working.
   ok = wolff:stop_and_delete_supervised_producers(Producers0),
   %% Some time for `wolff_client:delete_producers_metadata' to be processed.

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -535,22 +535,22 @@ key(Name) ->
   iolist_to_binary(io_lib:format("~0p/~0p/~0p", [Name, calendar:local_time(), erlang:system_time()])).
 
 count_partitions(Topic) ->
-    Cmd = kafka_topic_cmd_base(Topic) ++ " --describe | grep Configs | awk '{print $4}'",
-    list_to_integer(string:strip(os:cmd(Cmd), right, $\n)).
+  Cmd = kafka_topic_cmd_base(Topic) ++ " --describe | grep Configs | awk '{print $4}'",
+  list_to_integer(string:strip(os:cmd(Cmd), right, $\n)).
 
 ensure_partitions(Topic, Partitions) ->
-    Cmd = kafka_topic_cmd_base(Topic) ++ " --alter --partitions " ++ integer_to_list(Partitions),
-    Result = os:cmd(Cmd),
-    Pattern = "Adding partitions succeeded!",
-    ?assert(string:str(Result, Pattern) > 0),
-    ok.
+  Cmd = kafka_topic_cmd_base(Topic) ++ " --alter --partitions " ++ integer_to_list(Partitions),
+  Result = os:cmd(Cmd),
+  Pattern = "Adding partitions succeeded!",
+  ?assert(string:str(Result, Pattern) > 0),
+  ok.
 
 kafka_topic_cmd_base(Topic) when is_binary(Topic) ->
-    kafka_topic_cmd_base(binary_to_list(Topic));
+  kafka_topic_cmd_base(binary_to_list(Topic));
 kafka_topic_cmd_base(Topic) ->
-    "docker exec wolff-kafka-1 /opt/kafka/bin/kafka-topics.sh" ++
-    " --zookeeper zookeeper:2181" ++
-    " --topic '" ++ Topic ++ "'".
+  "docker exec wolff-kafka-1 /opt/kafka/bin/kafka-topics.sh" ++
+  " --zookeeper zookeeper:2181" ++
+  " --topic '" ++ Topic ++ "'".
 
 get_telemetry_seq(Table, Event) ->
     wolff_tests:get_telemetry_seq(Table, Event).

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -532,8 +532,7 @@ producer_config(Name) ->
    }.
 
 key(Name) ->
-  iolist_to_binary(io_lib:format("~p/~p/~p", [Name, calendar:local_time(),
-                                              erlang:system_time()])).
+  iolist_to_binary(io_lib:format("~0p/~0p/~0p", [Name, calendar:local_time(), erlang:system_time()])).
 
 count_partitions(Topic) ->
     Cmd = kafka_topic_cmd_base(Topic) ++ " --describe | grep Configs | awk '{print $4}'",


### PR DESCRIPTION
Support dynamic topics for supervised producers.
Call `wolff:ensure_supervised_dynamic_producers(ClientId, #{group => GroupName, ...})` to start a group-producer with no topics added in advance.
And call `wolff:send2` or `wolff:send_sync2` to publish messages with topic provided as an argument.