### PR TITLE
fix: ensure at least one leader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,17 @@
+* 3.0.2
+  - Fixed an issue where metadata was not correctly updated after terminating a producer.
+
+* 3.0.1
+  - Support dynamic topics for supervised producers.
+    Call `wolff:ensure_supervised_dynamic_producers(ClientId, #{group => GroupName, ...})` to
+    start a group-producer with no topics added in advance.
+    And call `wolff:send2` or `wolff:send_sync2` to publish messages with topic provided as an argument.
+
 * 3.0.0
   - Deleted `round_robin` partition strategy.
   - Change `alias` to `group`.
     Add `#{group => <<"group1">>}` to producer config for namespacing the topic,
     so multiple producers for one topic will not clash each other when sharing the same client.
-  - Support dynamic topics for supervised producers.
-    Call `wolff:ensure_supervised_dynamic_producers(ClientId, #{group => GroupName, ...})` to
-    start a group-producer with no topics added in advance.
-    And call `wolff:send2` or `wolff:send_sync2` to publish messages with topic provided as an argument.
 
 * 2.0.0
   - Added the `alias` producer config option to make producers to the same topic be independent.

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -244,7 +244,7 @@ do_release_leader_conns(Group, Topic, St) ->
           %% Last entry: we may drop the connection metadata
           KnownTopics = maps:remove(Topic, KnownTopics0),
           Conns = close_connections(Conns0, Topic),
-          Topics = maps:remove(Group, Topics0),
+          Topics = maps:remove(Topic, Topics0),
           St#{metadata_ts := Topics, conns := Conns, known_topics := KnownTopics};
       #{Topic := #{Group := true} = KnownProducers0} ->
           %% Connection is still being used by other producers.

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -113,21 +113,25 @@ different_producers_same_topic_test() ->
                          filelib:is_dir(filename:join([BaseDir, File])),
                          lists:member(list_to_binary(File), [Dir0, Dir1])],
   ?assertMatch([_, _], ReplayQDirs, #{base_dir => Files}),
-  ?assertMatch(#{known_topics := #{Topic := #{Group0 := true, Group1 := true}},
+  ?assertMatch(#{metadata_ts := #{Topic := _},
+                 known_topics := #{Topic := #{Group0 := true, Group1 := true}},
                  conns := #{{Topic, 0} := _}
                 }, sys:get_state(ClientPid)),
   %% We now stop one of the producers.  The other should keep working.
   ok = wolff:stop_and_delete_supervised_producers(Producers0),
-  ?assertMatch(#{known_topics := #{Topic := #{Group1 := true}},
+  ?assertMatch(#{metadata_ts := #{Topic := _},
+                 known_topics := #{Topic := #{Group1 := true}},
                  conns := #{{Topic, 0} := _}
                 }, sys:get_state(ClientPid)),
   ?assertMatch(#{}, sys:get_state(ClientPid)),
   {_Partition1B, _ProducerPid1B} = wolff:send(Producers1, [Msg], AckFun),
   receive acked -> ok end,
   ok = wolff:stop_and_delete_supervised_producers(Producers1),
-  ?assertMatch(#{known_topics := Topics,
-                 conns := Conns
-                } when map_size(Topics) =:= 0 andalso map_size(Conns) =:= 0,
+  EmptyMap = #{},
+  ?assertMatch(#{metadata_ts := EmptyMap,
+                 known_topics := EmptyMap,
+                 conns := EmptyMap
+                },
                sys:get_state(ClientPid)),
   ok = wolff:stop_and_delete_supervised_client(ClientId),
   ok = application:stop(wolff),


### PR DESCRIPTION
Otherwise, an empty list might be returned if the client doens't actually attempt to ensure the leaders if the metadata is fresh.