### PR TITLE
feat: optimize disk buffer writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ wolff:send(Producers, [Msg], AckFun).
 * `max_linger_ms`: Age in milliseconds a batch can stay in queue when the connection
    is idle (as in no pending acks from kafka). Default=0 (as in send immediately).
 
+* `max_linger_bytes`: Number of bytes to collect before sending it to Kafka. If set to 0, `max_batch_bytes` is taken for mem-only mode, otherwise it's 10 times `max_batch_bytes` (but never exceeds 10MB) to optimize disk write.
+
 * `max_send_ahead`: Number of batches to be sent ahead without receiving ack for
    the last request. Must be 0 if messages must be delivered in strict order.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 * 4.0.0
   - Delete global stats (deprecated since 1.9).
+  - Move linger delay to front of the buffer queue.
+    The default value for `max_linger_ms` is `0` as before.
+    Setting `max_linger_ms=10` will make the disk write batch larger when buffer is configured to disk mode or disk-offload mode.
 
 * 3.0.4
   - Upgrade to kafka_protocol-4.1.8

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "4.0.0"},
+  {vsn, "git"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -123,7 +123,7 @@ stop_and_delete_supervised_producers(Producers) ->
 %% The partition number and the per-partition worker pid are returned in a tuple to caller,
 %% so it may use them to correlate the future `AckFun' evaluation.
 %% NOTE: This API is blocked until the batch is enqueued to the producer buffer, otherwise no backpressure.
-%%       High produce rate may cause execussive ram and disk usage.
+%%       High produce rate may cause excessive ram and disk usage.
 %% NOTE: In case producers are configured with `required_acks = none',
 %%       the second arg for callback function will always be `?UNKNOWN_OFFSET' (`-1').
 -spec send(producers(), [msg()], ack_fun()) -> {partition(), pid()}.

--- a/src/wolff.erl
+++ b/src/wolff.erl
@@ -34,11 +34,13 @@
 
 %% Messaging APIs
 -export([send/3,
-         send_sync/3
+         send_sync/3,
+         cast/3
         ]).
 
 %% Messaging APIs of dynamic producer.
 -export([send2/4,
+         cast2/4,
          send_sync2/4,
          add_topic/2,
          remove_topic/2
@@ -120,8 +122,8 @@ stop_and_delete_supervised_producers(Producers) ->
 %% In case `required_acks' is configured to `none', the callback is evaluated immediately after send.
 %% The partition number and the per-partition worker pid are returned in a tuple to caller,
 %% so it may use them to correlate the future `AckFun' evaluation.
-%% NOTE: This API has no backpressure,
-%%       high produce rate may cause execussive ram and disk usage.
+%% NOTE: This API is blocked until the batch is enqueued to the producer buffer, otherwise no backpressure.
+%%       High produce rate may cause execussive ram and disk usage.
 %% NOTE: In case producers are configured with `required_acks = none',
 %%       the second arg for callback function will always be `?UNKNOWN_OFFSET' (`-1').
 -spec send(producers(), [msg()], ack_fun()) -> {partition(), pid()}.
@@ -135,6 +137,22 @@ send(Producers, Batch, AckFun) ->
 send2(Producers, Topic, Batch, AckFun) ->
   {Partition, ProducerPid} = wolff_producers:pick_producer2(Producers, Topic, Batch),
   ok = wolff_producer:send(ProducerPid, Batch, AckFun),
+  {Partition, ProducerPid}.
+
+%% @doc Cast a batch to a partition producer.
+%% Even less backpressure than `send/3'.
+%% It does not wait for the batch to be enqueued to the producer buffer.
+-spec cast(producers(), [msg()], ack_fun()) -> {partition(), pid()}.
+cast(Producers, Batch, AckFun) ->
+  {Partition, ProducerPid} = wolff_producers:pick_producer(Producers, Batch),
+  ok = wolff_producer:send(ProducerPid, Batch, AckFun, no_wait_for_queued),
+  {Partition, ProducerPid}.
+
+%% @doc Topic as argument for dynamic producers, otherwise equivalent to `cast/3'.
+-spec cast2(producers(), topic(), [msg()], ack_fun()) -> {partition(), pid()}.
+cast2(Producers, Topic, Batch, AckFun) ->
+  {Partition, ProducerPid} = wolff_producers:pick_producer2(Producers, Topic, Batch),
+  ok = wolff_producer:send(ProducerPid, Batch, AckFun, no_wait_for_queued),
   {Partition, ProducerPid}.
 
 %% @doc Pick a partition producer and send a batch synchronously.

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -330,7 +330,7 @@ pick_next_alive(LookupFn, Partition, Count) ->
   pick_next_alive(LookupFn, (Partition + 1) rem Count, Count, _Tried = 1).
 
 pick_next_alive(_LookupFn, _Partition, Count, Count) ->
-  throw(#{cause => all_producers_down});
+  throw(#{cause => all_producers_down, count => Count});
 pick_next_alive(LookupFn, Partition, Count, Tried) ->
   Pid = LookupFn(Partition),
   case is_alive(Pid) of

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -627,7 +627,7 @@ test_message_too_large() ->
       Ref = make_ref(),
       Self = self(),
       AckFun = {fun ?MODULE:ack_cb/4, [Self, Ref]},
-      spawn(fun() -> wolff:send(Producers, Batch, AckFun) end),
+      {_, _} = wolff:cast(Producers, Batch, AckFun),
       fun() -> ?WAIT(5000, {ack, Ref, _Partition, BaseOffset}, BaseOffset) end
     end,
     %% Must be ok to send one message


### PR DESCRIPTION
Previously, the `wolff_producer` implementation was aggressive when trying to enqueue newly received calls,
even when `max_linger_ms` is set to non-zero because the linger was implemented at the popping end of the queue.

This change moves the linger timer to the pushing end of the queue, that is, the process will delay enqueue to allow a larger collection of concurrent calls so the write batch towards disk can be larger

This also means when `max_linger_ms` is not zero, the concurrent callers will get blocked while lingering,
For completely non-blocking API, call `cast/3` or `cast/4` instead.