### PR TITLE
refactor: compact pending-acks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
   - Move linger delay to front of the buffer queue.
     The default value for `max_linger_ms` is `0` as before.
     Setting `max_linger_ms=10` will make the disk write batch larger when buffer is configured to disk mode or disk-offload mode.
+  - Lower RAM usage with compact `pending_acks` data structure when the callbacks are static.
 
 * 3.0.4
   - Upgrade to kafka_protocol-4.1.8

--- a/src/wolff_pendack.erl
+++ b/src/wolff_pendack.erl
@@ -1,0 +1,122 @@
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+
+%% @doc Implement a data structure to hold pending acks towards `send' or `cast'
+%% callers.
+%% The pending acks are stored in a queue,
+%% each item in the queue is a pair of call IDs and callback.
+%% The call ID is a monotonically increasing integer, starting from current
+%% time in microseconds.
+-module(wolff_pendack).
+
+-export([new/0, count/1, insert/2, take/2]).
+
+-export_type([acks/0]).
+
+-type call_id() :: pos_integer().
+-type key() :: call_id() | {call_id(), call_id()}.
+-type cb() :: term().
+-opaque acks() :: #{next_id := integer(),
+                    cbs := queue:queue({key(), cb()})}.
+
+%% @doc Initialize a new data structure.
+new() ->
+    %% use a timestamp for call ID base so the items recovered from disk
+    %% will not be possible to clash with newer generation call after
+    %% the process crashed or node restarted.
+    Now = erlang:system_time(microsecond),
+    #{next_id => Now,
+      cbs => queue:new()
+     }.
+
+%% @doc count the total number of pending acks.
+-spec count(acks()) -> non_neg_integer().
+count(#{cbs := Cbs}) ->
+    sum(queue:to_list(Cbs), 0).
+
+sum([], Acc) ->
+    Acc;
+sum([{CallId, _} | Rest], Acc) when is_integer(CallId) ->
+    sum(Rest, Acc + 1);
+sum([{{MinCallId, MaxCallId}, _} | Rest], Acc) ->
+    sum(Rest, Acc + MaxCallId - MinCallId + 1).
+
+%% @doc insert a callback into the data structure.
+-spec insert(acks(), cb()) -> {call_id(), acks()}.
+insert(#{next_id := Id, cbs := Cbs} = X, Cb) ->
+    NewCbs = insert_cb(Cbs, Id, Cb),
+    {Id, X#{next_id => Id + 1, cbs => NewCbs}}.
+
+insert_cb(Cbs, Id, Cb) ->
+    case queue:out_r(Cbs) of
+        {empty, _} ->
+            queue:in({Id, Cb}, Cbs);
+        {{value, {Key1, Cb1}}, Cbs1} ->
+            insert_cb1(Cbs1, Key1, Cb1, Id, Cb)
+    end.
+
+%% If the callback is identical to the previous one, then just update the
+%% call ID range.
+%% Otherwise, insert the new callback.
+insert_cb1(Cbs, Key, Cb, Id, Cb1) when Cb =:= Cb1 ->
+    Key1 = expand_id(Key, Id),
+    queue:in({Key1, Cb1}, Cbs);
+insert_cb1(Cbs, Key, Cb, Id, Cb1) ->
+    queue:in({Id, Cb1}, queue:in({Key, Cb}, Cbs)).
+
+%% If the ID is a single integer, then expand it to a range.
+expand_id(Id0, Id) when is_integer(Id0) ->
+    Id =:= Id0 + 1 orelse error({unexpected_id, Id0, Id}),
+    expand_id({Id0, Id0}, Id);
+expand_id({MinId, MaxId}, Id) ->
+    Id =:= MaxId + 1 orelse error({unexpected_id, {MinId, MaxId}, Id}),
+    {MinId, Id}.
+
+%% @doc Take the callback for a given call ID.
+%% The ID is expected to be the oldest in the queue.
+%% Return the callback and the updated data structure.
+-spec take(acks(), call_id()) -> {ok, cb(), acks()} | false.
+take(#{cbs := Cbs} = X, Id) ->
+    case take1(Cbs, Id) of
+        false ->
+            %% stale ack
+            false;
+        {ok, Cb, Cbs1} ->
+            {ok, Cb, X#{cbs => Cbs1}}
+    end.
+
+take1(Cbs0, Id) ->
+    case queue:out(Cbs0) of
+        {empty, _} ->
+            false;
+        {{value, {Key, Cb}}, Cbs} ->
+            take2(Cbs, Key, Cb, Id)
+    end.
+
+take2(Cbs, Id0, Cb, Id) when is_integer(Id0) ->
+    take2(Cbs, {Id0, Id0}, Cb, Id);
+take2(_Cbs, {MinId, _MaxId}, _Cb, Id) when Id < MinId ->
+    %% stale ack
+    false;
+take2(Cbs, {MinId, MaxId}, Cb, Id) when Id =:= MinId ->
+    %% ack the oldest item
+    case MaxId =:= MinId of
+        true ->
+            {ok, Cb, Cbs};
+        false ->
+            {ok, Cb, queue:in_r({{Id + 1, MaxId}, Cb}, Cbs)}
+    end;
+take2(_Cbs, {MinId, MaxId}, _Cb, Id) ->
+    error(#{cause => unexpected_id, min => MinId, max => MaxId, got => Id}).

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2018-2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2018-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -97,7 +97,6 @@
 -define(no_queued_reply, no_queued_reply).
 -define(ACK_CB(AckCb, Partition), {AckCb, Partition}).
 -define(no_queue_ack, no_queue_ack).
--define(no_caller_ack, no_caller_ack).
 -define(MAX_LINGER_BYTES, (10 bsl 20)).
 -type ack_fun() :: wolff:ack_fun().
 -type send_req() :: ?SEND_REQ({pid(), reference()}, [wolff:msg()], ack_fun()).
@@ -107,13 +106,12 @@
                   attempts := pos_integer()
                  }.
 
--type state() :: #{ call_id_base := pos_integer()
-                  , client_id := wolff:client_id()
+-type state() :: #{ client_id := wolff:client_id()
                   , config := config_state()
                   , conn := undefined | _
                   , ?linger_expire_timer := false | reference()
                   , partition := partition()
-                  , pending_acks := #{} % CallId => AckCb
+                  , pending_acks := wolff_pendack:acks()
                   , produce_api_vsn := undefined | _
                   , replayq := replayq:q()
                   , sent_reqs := queue:queue(sent())
@@ -277,8 +275,7 @@ do_init(#{client_id := ClientId,
   wolff_metrics:inflight_set(Config, 0),
   St#{replayq => Q,
       config := Config,
-      call_id_base => erlang:system_time(microsecond),
-      pending_acks => #{}, % CallId => AckCb
+      pending_acks => wolff_pendack:new(),
       produce_api_vsn => undefined,
       sent_reqs => queue:new(), % {kpro:req(), replayq:ack_ref(), [{CallId, MsgCount}]}
       sent_reqs_count => 0,
@@ -387,9 +384,6 @@ ensure_ts(Batch) ->
   lists:map(fun(#{ts := _} = Msg) -> Msg;
                (Msg) -> Msg#{ts => now_ts()}
             end, Batch).
-
-make_call_id(Base) ->
-  Base + erlang:unique_integer([positive]).
 
 resolve_max_linger_bytes(#{max_linger_bytes := 0,
                            max_batch_bytes := Mb
@@ -568,12 +562,7 @@ get_batch_from_queue_items([], Acc) ->
 get_batch_from_queue_items([?Q_ITEM(_CallId, _Ts, Batch) | Items], Acc) ->
   get_batch_from_queue_items(Items, lists:reverse(Batch, Acc)).
 
-count_calls([]) ->
-  0;
-count_calls([?Q_ITEM(?no_caller_ack, _Ts, _Batch) | Rest]) ->
-  count_calls(Rest);
-count_calls([?Q_ITEM(_CallId, _Ts, _Batch) | Rest]) ->
-  1 + count_calls(Rest).
+count_calls(Items) -> length(Items).
 
 count_msgs([]) ->
   0;
@@ -761,16 +750,14 @@ ensure_delayed_reconnect(St, _Delay) ->
   St.
 
 evaluate_pending_ack_funs(PendingAcks, [], _BaseOffset) -> PendingAcks;
-evaluate_pending_ack_funs(PendingAcks, [{?no_caller_ack, BatchSize} | Rest], BaseOffset) ->
-  evaluate_pending_ack_funs(PendingAcks, Rest, offset(BaseOffset, BatchSize));
 evaluate_pending_ack_funs(PendingAcks, [{CallId, BatchSize} | Rest], BaseOffset) ->
   NewPendingAcks =
-    case maps:get(CallId, PendingAcks, false) of
-      false ->
-        PendingAcks;
-      AckCb ->
+    case wolff_pendack:take(PendingAcks, CallId) of
+      {ok, AckCb, PendingAcks1} ->
         ok = eval_ack_cb(AckCb, BaseOffset),
-        maps:without([CallId], PendingAcks)
+        PendingAcks1;
+      false ->
+        PendingAcks
     end,
   evaluate_pending_ack_funs(NewPendingAcks, Rest, offset(BaseOffset, BatchSize)).
 
@@ -910,18 +897,16 @@ enqueue_calls(#{calls := #{batch_r := CallsR}} = St0, no_linger) ->
 enqueue_calls2(Calls,
                #{replayq := Q,
                  pending_acks := PendingAcks0,
-                 call_id_base := CallIdBase,
                  partition := Partition,
                  config := Config0
                 } = St0) ->
   {QueueItems, PendingAcks, CallByteSize} =
     lists:foldl(
       fun(?SEND_REQ(_From, Batch, AckFun), {Items, PendingAcksIn, Size}) ->
-          CallId = make_call_id(CallIdBase),
           %% keep callback funs in memory, do not seralize it into queue because
           %% saving anonymous function to disk may easily lead to badfun exception
           %% in case of restart on newer version beam.
-          PendingAcksOut = PendingAcksIn#{CallId => ?ACK_CB(AckFun, Partition)},
+          {CallId, PendingAcksOut} = wolff_pendack:insert(PendingAcksIn, ?ACK_CB(AckFun, Partition)),
           NewItems = [make_queue_item(CallId, Batch) | Items],
           {NewItems, PendingAcksOut, Size + batch_bytes(Batch)}
       end, {[], PendingAcks0, 0}, Calls),


### PR DESCRIPTION
Prior to this change, the producer uses a map to hold pending acks under the assumption that the map values should be small.
in some complex scenarios, however, the ack callback contexts can be large terms this result in great RAM consumption when there are many to ack.

This PR optimizes RAM usage by:
1. Change the call IDs to sequential
2. Do not store a copy of the context if it's identical to the last call.