### PR TITLE
Fix metdata fetch failure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 4.0.2
+  - Fix dynamic topic producer initialization failure handling.
+
 * 4.0.1
   - Minimize callback context for sync call.
   - Upgrade to kafka_protocl-4.1.9 for OTP 27.

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -493,8 +493,8 @@ do_add_topic(#{my_id := ?NS_TOPIC(Group, ?DYNAMIC),
       discard ->
         ok = mark_topic_unknown(Group, Topic),
         {#{}, {error, unknown_topic_or_partition}};
-      {error, ?not_initialized(_, Reason) = TopicStatus1} ->
-        {TopicStatus1, {error, Reason}}
+      {error, ?not_initialized(_, Reason) = Error} ->
+        {#{Topic => Error}, {error, Reason}}
     end,
   {St#{producers_status := maps:merge(Status, TopicStatus)}, Reply}.
 


### PR DESCRIPTION
Fixes a crash like this:

Generic server <0.4455.0> terminating. Reason: {{badmap,{not_initialized,1,failed_to_fetch_metadata}},[{maps,merge,[#{},{not_initialized,1,failed_
to_fetch_metadata}],[{error_info,#{module => erl_stdlib_errors}}]},{wolff_producers,do_add_topic,2,[{file,"/mnt/code/src/emqx/0/_build/default/lib/wolff/src/wolff_producers.erl"},{line,49
9}]},{wolff_producers,handle_call,3,[{file,"/mnt/code/src/emqx/0/_build/default/lib/wolff/src/wolff_producers.erl"},{line,454}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},