### PR TITLE
Fix pending ack handling for buffer overflow drops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 * 4.0.2
-  - Fix dynamic topic producer initialization failure handling.
+  - Fix dynamic topic producer initialization failure handling (introduced in 3.0.0).
+  - Fix `unexpected_id` crash when replayq overflow.
 
 * 4.0.1
   - Minimize callback context for sync call.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 * 4.0.2
   - Fix dynamic topic producer initialization failure handling (introduced in 3.0.0).
-  - Fix `unexpected_id` crash when replayq overflow.
+  - Fix `unexpected_id` crash when replayq overflow (introduced in 4.0.1).
 
 * 4.0.1
   - Minimize callback context for sync call.

--- a/src/wolff_pendack.erl
+++ b/src/wolff_pendack.erl
@@ -133,7 +133,7 @@ drop1(#{backlog := Cbs0, count := Count} = X, [Id | Ids], Acc) ->
         false ->
             drop1(X, Ids, Acc);
         {ok, Cb, Cbs}  ->
-            drop1(X#{backlog => Cbs, count => Count - 1}, Ids, [Cb | Acc])
+            drop1(X#{backlog := Cbs, count := Count - 1}, Ids, [Cb | Acc])
     end.
 
 %% @doc Move a list of calls from the head of the backlog queue
@@ -150,5 +150,5 @@ move1(#{backlog := Backlog0, inflight := Inflight0} = X, Id) ->
             X;
         {ok, Cb, Backlog} ->
             Inflight = insert_cb(Inflight0, Id, Cb),
-           X#{backlog => Backlog, inflight => Inflight}
+           X#{backlog := Backlog, inflight := Inflight}
     end.

--- a/test/wolff_dynamic_topics_tests.erl
+++ b/test/wolff_dynamic_topics_tests.erl
@@ -96,8 +96,8 @@ ack_cb_interlave_test() ->
   %% inspect the pending acks
   #{conn := Conn, pending_acks := Acks} = sys:get_state(Pid),
   ?assertEqual(N * 2, wolff_pendack:count(Acks)),
-  #{cbs := Cbs} = Acks,
-  ?assertEqual(N * 2, queue:len(Cbs)),
+  #{inflight := Inflight, backlog := Backlog} = Acks,
+  ?assertEqual(N * 2, queue:len(Backlog) + queue:len(Inflight)),
   %% resume the connection
   sys:resume(Conn),
   %% wait for 2*N acks

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -331,7 +331,7 @@ replayq_overflow_while_inflight_test() ->
   Pid = wolff_producers:lookup_producer(Producers, 0),
   ?assert(is_process_alive(Pid)),
   TesterPid = self(),
-  ok = meck:new(kpro, [non_strict, no_history, no_link, passthrough]),
+  ok = meck:new(kpro, [no_history, no_link, passthrough]),
   meck:expect(kpro, send,
               fun(_Conn, Req) ->
                       Payload = iolist_to_binary(lists:last(tuple_to_list(Req))),

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -316,6 +316,69 @@ zero_ack_test() ->
   ets:delete(CntrEventsTable),
   deinstall_event_logging(?FUNCTION_NAME).
 
+replayq_overflow_while_inflight_test() ->
+  ClientCfg = client_config(),
+  {ok, Client} = start_client(<<"client-1">>, ?HOSTS, ClientCfg),
+  Msg = fun(Value) -> #{key => <<>>, value => Value} end,
+  Batch = fun(Value) -> [Msg(Value), Msg(Value)] end,
+  BatchSize = wolff_producer:batch_bytes(Batch(<<"testdata1">>)),
+  ProducerCfg = #{max_batch_bytes => 1, %% ensure send one call at a time
+                  replayq_max_total_bytes => BatchSize,
+                  required_acks => all_isr,
+                  max_send_ahead => 0 %% ensure one sent to kafka at a time
+                 },
+  {ok, Producers} = wolff:start_producers(Client, <<"test-topic">>, ProducerCfg),
+  Pid = wolff_producers:lookup_producer(Producers, 0),
+  ?assert(is_process_alive(Pid)),
+  TesterPid = self(),
+  ok = meck:new(kpro, [non_strict, no_history, no_link, passthrough]),
+  meck:expect(kpro, send,
+              fun(_Conn, Req) ->
+                      Payload = iolist_to_binary(lists:last(tuple_to_list(Req))),
+                      [_, <<N, _/binary>>] = binary:split(Payload, <<"testdata">>),
+                      TesterPid ! {sent_to_kafka, <<"testdata", N>>},
+                      ok
+              end),
+  AckFun1 = fun(_Partition, BaseOffset) -> TesterPid ! {ack_1, BaseOffset}, ok end,
+  AckFun2 = fun(_Partition, BaseOffset) -> TesterPid ! {ack_2, BaseOffset}, ok end,
+  AckFun3 = fun(_Partition, BaseOffset) -> TesterPid ! {ack_3, BaseOffset}, ok end,
+  SendF = fun(AckFun, Value) -> wolff:send(Producers, Batch(Value), AckFun) end,
+  %% send 3 batches first will be inflight, 2nd is overflow (kicked out by the 3rd)
+  proc_lib:spawn_link(fun() -> SendF(AckFun1, <<"testdata1">>) end),
+  proc_lib:spawn_link(fun() -> timer:sleep(5), SendF(AckFun2, <<"testdata2">>) end),
+  proc_lib:spawn_link(fun() -> timer:sleep(10), SendF(AckFun3, <<"testdata3">>) end),
+  try
+    %% the 1st batch is sent to Kafka, but no reply, so no ack
+    receive
+      {sent_to_kafka, <<"testdata1">>} -> ok;
+      {ack_1, _} -> error(unexpected)
+    after
+        2000 ->
+            error(timeout)
+    end,
+    %% the 2nd batch should be dropped (pushed out by the 3rd)
+    receive
+      {ack_2, buffer_overflow_discarded} -> ok;
+      {sent_to_kafka, <<"testdata2">>} -> error(unexpected);
+      {sent_to_kafka, Offset2} -> error({unexpected, Offset2})
+    after
+        2000 ->
+            io:format(user, "~p~n", [sys:get_state(Pid)]),
+            error(timeout)
+    end,
+    %% the 3rd batch should stay in the queue
+    receive
+      {ack_3, Any} -> error({unexpected, Any})
+    after
+        100 ->
+            ok
+    end
+  after
+    meck:unload(kpro),
+    ok = wolff:stop_producers(Producers),
+    ok = stop_client(Client)
+  end.
+
 replayq_overflow_test() ->
   CntrEventsTable = ets:new(cntr_events, [public]),
   install_event_logging(?FUNCTION_NAME, CntrEventsTable, false),
@@ -928,7 +991,9 @@ install_event_logging(TestCaseName, EventRecordTable, LogEvents) ->
         fun wolff_tests:handle_telemetry_event/4,
         #{record_table => EventRecordTable,
           log_events => LogEvents}
-    ).
+    ),
+    timer:sleep(100),
+    ok.
 
 telemetry_events() ->
     [


### PR DESCRIPTION
introduced in 4.0.0 (the pending-ack compaction feature), when there are a few requests sent inflight, AND the replayq buffer overflows, the overflown calls to be dropped are in the middle of the compacted call-id range, hence caused below assertion failure:

{cause => unexpected_id,max => 1728471879846415,min => 1728471879846415,got => 1728471879846430},[{wolff_pendack,take2,4,[{file,"wolff_pendack.erl"},{line,122}]},{wolff_pendack,take,2,[{f
ile,"wolff_pendack.erl"},{line,92}]},{wolff_producer,evaluate_pending_ack_funs,3,[{file,"wolff_producer.erl"},{line,755}]},{wolff_producer,handle_overflow,2,[{file,"wolff_producer.erl"},{line,957}]}

The fix is to keep two queues for pending acks instead, one for the backlog (replayq buffer), another for inflight.