### PR TITLE
fix: unexpected_id crash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 4.0.5
+  - Fix `unexpected_id` crash introduced in 4.0.1.
+
 * 4.0.4
   - Upgrade to kafka_protocol-4.1.10 for discover/connect timeout fix.
   - Upgrade to replayq from 0.3.4 to 0.3.10.

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -514,20 +514,20 @@ send_to_kafka(#{sent_reqs := SentReqs,
   NewInflightCalls = InflightCalls + NrOfCalls,
   _ = wolff_metrics:inflight_set(Config, NewInflightCalls),
   #kpro_req{ref = Ref, no_ack = NoAck} = Req = make_request(Items, St0),
-  St1 = St0#{replayq := NewQ},
   Sent = #{req_ref => Ref,
            q_items => Items,
            q_ack_ref => QAckRef,
            attempts => 1
           },
-  St2 = St1#{sent_reqs := queue:in(Sent, SentReqs),
+  St1 = St0#{replayq := NewQ,
+             sent_reqs := queue:in(Sent, SentReqs),
              sent_reqs_count := NewSentReqsCount,
              inflight_calls := NewInflightCalls,
              pending_acks := NewPendingAcks
             },
   ok = request_async(Conn, Req),
-  St3 = maybe_fake_kafka_ack(NoAck, Sent, St2),
-  maybe_send_to_kafka(St3).
+  St2 = maybe_fake_kafka_ack(NoAck, Sent, St1),
+  maybe_send_to_kafka(St2).
 
 %% when require no acks do not add to sent_reqs and ack caller immediately
 maybe_fake_kafka_ack(_NoAck = true, Sent, St) ->


### PR DESCRIPTION
Introduced in 4.0.1, the sequential ID assertion only applies to the backlog items, but not for the inflight items. Because backlog queue head can be dropped when overloaded, if the inflight is not empty, when drop happened, the next insertion to inflight will detect a gap and crash.

This commit allows the gap for inflight queue.