### PR TITLE
250219 receive leader connection exit reason

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - '24.1'
-          - '23.3.4.7'
+          - '25'
+          - '24'
         kafka:
           - '2.4'
           - '1.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,5 @@ jobs:
     - name: Run tests
       run: |
           ./start-kafka.sh
-          make eunit || (cd scripts && docker-compose logs)
+          make eunit || (cd scripts && docker compose logs)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ wolff:send(Producers, [Msg], AckFun).
 Start Kafka in docker containers from dokcer-compose.yml in this repo.
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 ## License

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+* 1.5.15
+  - Improve logging for leader connection down reason.
+    Previously, if the connection is closed immediately after connected, the producer process may not get the chance to monitor the pid to get its exit reason.
+    Now wolff_client handles the 'EXIT' signal and keep it for future logging purpose.
+* 1.5.14
+  - Split batch if it's too large for Kafka.
 * 1.5.13
   - Use long-lived metadata connection.
     This is to avoid having to excessively re-establish connection when there are many concurrent connectivity checks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: wurstmeister/zookeeper

--- a/include/wolff.hrl
+++ b/include/wolff.hrl
@@ -2,7 +2,6 @@
 -define(WOLFF_HRL, true).
 
 -define(conn_down(Reason), {down, Reason}).
--define(conn_error(Reason), {error, Reason}).
 -define(leader_connection(Pid), {leader_connection, Pid}).
 -define(UNKNOWN_OFFSET, -1).
 -define(buffer_overflow_discarded, buffer_overflow_discarded).

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.14"},
+  {vsn, "1.5.15"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
-{"1.5.14",
+{"1.5.15",
   [
-   {<<"1\\.5\\.1[1-3]">>,
+   {<<"1\\.5\\.1[1-4]">>,
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
      , {load_module, wolff_producers, brutal_purge, soft_purge, []}
      , {load_module, wolff_producer, brutal_purge, soft_purge, []}

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -256,9 +256,6 @@ handle_info(?leader_connection(Conn), #{topic := Topic,
 handle_info(?leader_connection(?conn_down(Reason)), St0) ->
   St = mark_connection_down(St0#{reconnect_timer => ?no_timer}, Reason),
   {noreply, St};
-handle_info(?leader_connection(?conn_error(Reason)), St0) ->
-  St = mark_connection_down(St0#{reconnect_timer => ?no_timer}, Reason),
-  {noreply, St};
 handle_info(?reconnect, St0) ->
   St = St0#{reconnect_timer => ?no_timer},
   {noreply, ensure_delayed_reconnect(St, normal_delay)};

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-docker-compose up -d
+docker compose up -d
 
 n=0
 while ! docker exec wolff-kafka-2 bash -c '/opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper --list' | grep 'test-topic'; do

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -387,6 +387,10 @@ client_state_upgrade_test() ->
   ok = application:stop(wolff).
 
 fail_to_connect_all_test() ->
+  {timeout, 30,
+   fun() -> test_fail_to_connect_all() end}.
+
+test_fail_to_connect_all() ->
   ClientId = <<"fail-to-connect-test">>,
   _ = application:stop(wolff), %% ensure stopped
   {ok, _} = application:ensure_all_started(wolff),


### PR DESCRIPTION
Two fixes:
1. If a partition-leader connection is down before any producer process get a chance to monitor it, the reason is lost. Now the EXIT reason is kept in wolff_client state.
2. If a partition is not found in the metadata response, `wolff_client` will not crash with a `badmatch`, it keeps `partition_missing_in_metadata_response` as error reason in the state for logging purpose

Will send a followup PR to support partition-count shrinking (previously only supported increasing).