### PR TITLE
feat: handle topic recreation with less number of partitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 * 1.5.15
+  - Handle topic recreation with fewer partitions.
+    Previously, Wolff only handled topic alteration with more partitions, but not topic re-creation with fewer partitions.
+    Now deleted partition producers will be gracefully shut down once new metadata is fetched, and the buffered messages will be dropped.
+    NOTE: As before, topic deletion (unknown_topic_or_partition) does not cause all partition producers to shut down.
   - Improve logging for leader connection down reason.
     Previously, if the connection is closed immediately after connected, the producer process may not get the chance to monitor the pid to get its exit reason.
     Now wolff_client handles the 'EXIT' signal and keep it for future logging purpose.

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -173,6 +173,8 @@ handle_cast({recv_leader_connection, Topic, Partition, Caller}, St0) ->
         {_, Pid} ->
           Pid;
         false ->
+          %% this happens as a race between metadata refresh and partition producer shutdown
+          %% partition producer will be shutdown by wolff_producers after metadata refresh is complete
           partition_missing_in_metadata_response
       end,
       _ = erlang:send(Caller, ?leader_connection(MaybePid)),

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -299,9 +299,17 @@ ensure_leader_connections2(#{conn_config := ConnConfig,
 
 ensure_leader_connections3(#{metadata_ts := MetadataTs} = St0, Topic,
                            ConnPid, Brokers, PartitionMetaList) ->
-  St = lists:foldl(fun(PartitionMeta, StIn) ->
-                       ensure_leader_connection(StIn, Brokers, Topic, PartitionMeta)
-                   end, St0, PartitionMetaList),
+  OldPartitions = lists:map(fun({P, _}) -> P end, do_get_leader_connections(St0, Topic)),
+  NewPartitions = lists:map(fun(PartitionMeta) ->
+                                kpro:find(partition, PartitionMeta)
+                            end, PartitionMetaList),
+  DeletedPartitions = lists:subtract(OldPartitions, NewPartitions),
+  St1 = lists:foldl(fun(PartitionMeta, StIn) ->
+                        ensure_leader_connection(StIn, Brokers, Topic, PartitionMeta)
+                    end, St0, PartitionMetaList),
+  St = lists:foldl(fun(Partition, StIn) ->
+                      maybe_disconnect_old_leader(StIn, Topic, Partition, partition_missing_in_metadata_response)
+                  end, St1, DeletedPartitions),
   {ok, St#{metadata_ts := MetadataTs#{Topic => erlang:timestamp()},
            metadata_conn => ConnPid
           }}.
@@ -336,9 +344,9 @@ do_ensure_leader_connection(#{conn_config := ConnConfig,
       {needs_reconnect, OldConn} ->
         %% delegate to a process to speed up
         ok = close_connection(OldConn),
-        add_conn(do_connect(Host, ConnConfig), ConnId, Connections0);
+        update_conn(do_connect(Host, ConnConfig), ConnId, Connections0);
       false ->
-        add_conn(do_connect(Host, ConnConfig), ConnId, Connections0)
+        update_conn(do_connect(Host, ConnConfig), ConnId, Connections0)
     end,
   St = St0#{conns := Connections},
   Leaders0 = maps:get(leaders, St0, #{}),
@@ -359,7 +367,7 @@ maybe_disconnect_old_leader(#{conns := Connections} = St, Topic, PartitionNum, E
       ConnId = {Topic, PartitionNum},
       MaybePid = maps:get(ConnId, Connections, false),
       is_pid(MaybePid) andalso close_connection(MaybePid),
-      St#{conns := add_conn({error, ErrorCode}, ConnId, Connections)};
+      St#{conns := update_conn({error, ErrorCode}, ConnId, Connections)};
     _ ->
       %% the connection is shared by producers (for different topics)
       %% so we do not close the connection here.
@@ -367,7 +375,11 @@ maybe_disconnect_old_leader(#{conns := Connections} = St, Topic, PartitionNum, E
       %% (due to the error code returned) there is no way to know which
       %% connection to close anyway.
       Leaders0 = maps:get(leaders, St, #{}),
-      Leaders = Leaders0#{{Topic, PartitionNum} => ErrorCode},
+      Leaders = case ErrorCode of
+                  partition_missing_in_metadata_response ->
+                    maps:remove({Topic, PartitionNum}, Leaders0);
+                  _ -> Leaders0#{{Topic, PartitionNum} => ErrorCode}
+                end,
       St#{leaders => Leaders}
   end.
 
@@ -400,12 +412,14 @@ is_connected(MaybePid, {Host, Port}) ->
 
 is_alive(Pid) -> is_pid(Pid) andalso erlang:is_process_alive(Pid).
 
-add_conn({ok, Pid}, ConnId, Conns) ->
-    true = is_pid(Pid), %% assert
-    Conns#{ConnId => Pid};
-add_conn({error, Reason}, ConnId, Conns) ->
-    false = is_pid(Reason), %% assert
-    Conns#{ConnId => Reason}.
+update_conn({ok, Pid}, ConnId, Conns) ->
+  true = is_pid(Pid), %% assert
+  Conns#{ConnId => Pid};
+update_conn({error, partition_missing_in_metadata_response}, ConnId, Conns) ->
+  maps:remove(ConnId, Conns);
+update_conn({error, Reason}, ConnId, Conns) ->
+  false = is_pid(Reason), %% assert
+  Conns#{ConnId => Reason}.
 
 split_config(Config) ->
   ConnCfgKeys = kpro_connection:all_cfg_keys(),


### PR DESCRIPTION
Handle topic recreation with fewer partitions.
Previously, Wolff only handled topic alteration with more partitions, but not topic re-creation with fewer partitions.
Now deleted partition producers will be gracefully shut down once new metadata is fetched, and the buffered messages will be dropped.

NOTE: As before, topic deletion (`unknown_topic_or_partition`) does not cause all partition producers to shut down.