### PR TITLE
fix: handle metadata fetch error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - '25'
-          - '24'
+          - '25.3'
+          - '24.3'
         kafka:
           - '2.4'
           - '1.1'
@@ -41,7 +41,6 @@ jobs:
     - name: Install Erlang/OTP
       uses: erlef/setup-beam@v1
       with:
-        version-type: strict
         otp-version: ${{matrix.otp}}
         rebar3-version: '3.17.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - '2.4'
           - '1.1'
           - '0.11'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     # Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,16 @@ jobs:
 
     # Setup
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Cache Hex packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/hex/hexpm/packages
         key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
         restore-keys: |
           ${{ runner.os }}-hex-
     - name: Cache Dialyzer PLTs
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/rebar3_*_plt
         key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}

--- a/include/wolff.hrl
+++ b/include/wolff.hrl
@@ -5,6 +5,7 @@
 -define(leader_connection(Pid), {leader_connection, Pid}).
 -define(UNKNOWN_OFFSET, -1).
 -define(buffer_overflow_discarded, buffer_overflow_discarded).
+-define(partition_lost, partition_lost).
 
 %% Kafka has default batch size limit 1000012.
 %% Since Kafka 2.4, it has been extended to 1048588.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [{kafka_protocol, {git, "https://github.com/emqx/kafka_protocol", {tag, "2.3.6.6"}}},
-        {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.4"}}},
+        {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.5.2"}}},
         {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}}
        ]}.
 

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -180,7 +180,7 @@ handle_cast({recv_leader_connection, Topic, Partition, Caller}, St0) ->
       _ = erlang:send(Caller, ?leader_connection(MaybePid)),
       {noreply, St};
     {error, Reason} ->
-      _ = erlang:send(Caller, ?leader_connection({error, Reason})),
+      _ = erlang:send(Caller, ?leader_connection(?conn_down(Reason))),
       {noreply, St0}
   end;
 

--- a/src/wolff_producers.erl
+++ b/src/wolff_producers.erl
@@ -418,7 +418,7 @@ handle_partition_count_change(St, Connections0) ->
   St.
 
 stop_producer(Topic, Partition, Pid) ->
-  exit(Pid, shutdown),
+  ok = wolff_producer:stop(Pid, ?partition_lost),
   receive
     {'EXIT', Pid, _Reason} ->
       ok

--- a/test/wolff_supervised_tests.erl
+++ b/test/wolff_supervised_tests.erl
@@ -260,6 +260,68 @@ test_partition_count_decrease() ->
   ok = application:stop(wolff),
   ok.
 
+test_topic_recreate_test_() ->
+  {timeout, 30, %% it takes time to alter topic via cli in docker container
+   fun test_topic_recreate/0}.
+
+test_topic_recreate() ->
+  ClientId = <<"test-topic-recreate">>,
+  Topic = <<"test-topic-recreate">>,
+  %% ensure the topic does not exist
+  delete_topic(Topic),
+  Partitions0 = 3,
+  create_topic(Topic, Partitions0),
+  _ = application:stop(wolff), %% ensure stopped
+  {ok, _} = application:ensure_all_started(wolff),
+  ClientCfg = #{min_metadata_refresh_interval => 0},
+  {ok, ClientPid} = wolff:ensure_supervised_client(ClientId, ?HOSTS, ClientCfg),
+  {ok, Connections0} = wolff_client:get_leader_connections(ClientPid, Topic),
+  ?assertEqual(Partitions0, length(Connections0)),
+  Partitioner = fun(_Count, _Key) -> 0 end,
+  IntervalSeconds = 1,
+  Name = ?FUNCTION_NAME,
+  ProducerCfg = #{required_acks => all_isr,
+                  partitioner => Partitioner,
+                  reconnect_delay_ms => 0,
+                  name => Name,
+                  partition_count_refresh_interval_seconds => IntervalSeconds
+                 },
+  {ok, Producers} = wolff:ensure_supervised_producers(ClientId, Topic, ProducerCfg),
+  ?assertEqual(Partitions0, length(ets:tab2list(Name))),
+  Msg = #{key => ?KEY, value => <<"value">>},
+  ?assertEqual({0, 0}, wolff:send_sync(Producers, [Msg], 3000)),
+  %% delete the topic
+  delete_topic(Topic),
+  Self = self(),
+  %% Send a message while the topic is deleted
+  AckFn = fun(Partition, OffsetReply) -> Self ! {async_ack, Partition, OffsetReply}, ok end,
+  {0, _} = wolff:send(Producers, [Msg], AckFn),
+  %% wait for the topic to be deleted
+  create_topic(Topic, Partitions0 - 1),
+  %% wait for the topic to be recreated
+  timer:sleep(timer:seconds(IntervalSeconds * 4)),
+  {ok, Connections1} = wolff_client:get_leader_connections(ClientPid, Topic),
+  ?assertEqual(Partitions0 - 1, length(Connections1)),
+  %% ensure the producers are stopped
+  ?assertEqual(Partitions0 - 1, length(ets:tab2list(Name))),
+  ?assertEqual({0, 1}, wolff:send_sync(Producers, [Msg], 3000)),
+  receive
+    {async_ack, P, O} ->
+      ?assertEqual(0, P),
+      ?assertEqual(0, O)
+  after
+    1000 ->
+      error(timeout)
+  end,
+  %% cleanup
+  ok = wolff:stop_and_delete_supervised_producers(ClientId, Topic, Name),
+  ?assertEqual([], supervisor:which_children(wolff_producers_sup)),
+  ok = wolff:stop_and_delete_supervised_client(ClientId),
+  ?assertEqual([], supervisor:which_children(wolff_client_sup)),
+  ok = application:stop(wolff),
+  ok.
+
+
 non_existing_topic_test() ->
   ClientId = atom_to_binary(?FUNCTION_NAME),
   Topic = <<"non-existing-topic">>,


### PR DESCRIPTION
`{error, Reason}` tuple was not handled by wolff_producer (only expects `{conn_down, Reason}` tuple), causing the partition-leader re-discovery timer to be expired permanently.