### PR TITLE
chore: upgrade to kafka_ptotocol-4.2.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 4.0.11
+  - Upgrade to `kafka_protocol-4.2.8`. Fixed build speed and link issue for crc32c.
+
 * 4.0.10
   - Upgrade to `kafka_protocol-4.2.6`.
     Update test environment to test against Kafka 4.0.0 (KRaft mode)

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [ {kafka_protocol, "4.2.6"}
+{deps, [ {kafka_protocol, "4.2.8"}
        , {replayq, "0.4.1"}
        , {lc, "0.3.5"}
        , {telemetry, "1.1.0"}


### PR DESCRIPTION
previously, 4.2.6. this upgrade improved transient dependency crc32cer build speed and link issues