### PR TITLE
fix: handle record_list_too_large error in produce response

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 1.5.19
+  - Handle `record_list_too_large` error returned from Kafka.
+    Similar to `message_too_large`  error, the batch is split, then dropped if single call is still too large.
 * 1.5.18
   - Partition metadata handling.
     - Fixed an issue introduced in 1.5.15 where temporarily missing partitions in the metadata response could leave a `wolff_producer` process permanently disconnected.


### PR DESCRIPTION
Logic is similar to message_too_large: split the batch, if a single message is still too large, drop it.