### PR TITLE
250910 sync main 1.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+* 4.0.13 (merge 1.5.19)
+  - Handle `record_list_too_large` error returned from Kafka.
+    Similar to `message_too_large`  error, the batch is split, then dropped if single call is still too large.
+
 * 4.0.12 (merge 1.5.18)
   - Partition metadata handling.
     - Fixed an issue introduced in 4.0.7 (1.5.15) where temporarily missing partitions in the metadata response could leave a `wolff_producer` process permanently disconnected.

--- a/test/wolff_tests.erl
+++ b/test/wolff_tests.erl
@@ -833,7 +833,10 @@ test_leader_restart() ->
   end).
 
 with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, TestFunc) ->
-  ok = create_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes),
+    with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, default_sgement_bytes, TestFunc).
+
+with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes, TestFunc) ->
+  ok = create_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes),
   try
     _ = application:stop(wolff), %% ensure stopped
     {ok, _} = application:ensure_all_started(wolff),
@@ -842,23 +845,13 @@ with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, TestFunc) ->
     ok = delete_topic(Topic)
   end.
 
-
-message_too_large_test_() ->
-  {timeout, 60,
-   fun() -> test_message_too_large() end}.
-
-test_message_too_large() ->
-  Topic = "message-too-large-" ++ integer_to_list(abs(erlang:monotonic_time())),
-  Partitions = 1,
-  ReplicationFactor = 1,
-  MaxMessageBytes = 100,
-  with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, fun() ->
+test_batch_split_then_drop(Topic, MaxMessageBytes) ->
     ClientCfg = client_config(),
     ClientId = iolist_to_binary("client-" ++ Topic),
     {ok, Client} = start_client(ClientId, ?HOSTS, ClientCfg#{connection_strategy => per_partition}),
     TopicBin = iolist_to_binary(Topic),
     %% try to batch more messages than Kafka's limit,
-    %% the producer will get message_too_large error back
+    %% the producer will get message_too_large or record_list_too_large error back
     %% then it should retry sending one message at a time
     ProducerCfg = #{partitioner => fun(_, _) -> 0 end,
                     max_batch_bytes => MaxMessageBytes * 3,
@@ -894,8 +887,38 @@ test_message_too_large() ->
     ?assertEqual(message_too_large, (SendFunc([Msg(<<"0123456789">>)]))()),
     ok = wolff:stop_producers(Producers),
     ok = stop_client(Client),
-    ok = application:stop(wolff)
-  end).
+    ok = application:stop(wolff).
+
+%% Max message size is smaller than segment bytes to tigger record_list_too_large error.
+%% This is usually a bad server/topic configuration, but we need to cover it anyways.
+record_list_too_large_test_() ->
+  {timeout, 60,
+   fun() -> test_record_list_too_large() end}.
+
+test_record_list_too_large() ->
+  Topic = "record-list-too-large-" ++ integer_to_list(abs(erlang:monotonic_time())),
+  Partitions = 1,
+  ReplicationFactor = 1,
+  MaxMessageBytes = 1000,
+  SegmentBytes = 100,
+  with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes,
+    fun() ->
+      test_batch_split_then_drop(Topic, SegmentBytes)
+    end).
+
+message_too_large_test_() ->
+  {timeout, 60,
+   fun() -> test_message_too_large() end}.
+
+test_message_too_large() ->
+  Topic = "message-too-large-" ++ integer_to_list(abs(erlang:monotonic_time())),
+  Partitions = 1,
+  ReplicationFactor = 1,
+  MaxMessageBytes = 100,
+  with_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes,
+    fun() ->
+      test_batch_split_then_drop(Topic, MaxMessageBytes)
+    end).
 
 one_byte_limit_test_() ->
   {timeout, 10, fun one_byte_limit/0}.
@@ -1010,8 +1033,8 @@ encoded_bytes(Batch) ->
   Encoded = kpro_batch:encode(2, Batch, no_compression),
   iolist_size(Encoded).
 
-create_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes) ->
-  Cmd = create_topic_cmd(Topic, Partitions, ReplicationFactor, MaxMessageBytes),
+create_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes) ->
+  Cmd = create_topic_cmd(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes),
   Result = os:cmd(Cmd),
   Pattern = "Created topic ",
   ?assert(string:str(Result, Pattern) > 0, Result),
@@ -1020,7 +1043,7 @@ create_topic(Topic, Partitions, ReplicationFactor, MaxMessageBytes) ->
 delete_topic(Topic) ->
   wolff_test_utils:delete_topic(Topic).
 
-create_topic_cmd(Topic, Partitions, ReplicationFactor, MaxMessageBytes) ->
+create_topic_cmd(Topic, Partitions, ReplicationFactor, MaxMessageBytes, SegmentBytes) ->
   wolff_test_utils:topics_cmd_base(Topic) ++
   " --create" ++
   " --partitions " ++ integer_to_list(Partitions) ++
@@ -1028,6 +1051,12 @@ create_topic_cmd(Topic, Partitions, ReplicationFactor, MaxMessageBytes) ->
   case is_integer(MaxMessageBytes) of
     true ->
       " --config max.message.bytes=" ++ integer_to_list(MaxMessageBytes);
+    false ->
+      ""
+  end ++
+  case is_integer(SegmentBytes) of
+    true ->
+      " --config segment.bytes=" ++ integer_to_list(SegmentBytes);
     false ->
       ""
   end.


### PR DESCRIPTION
Port https://github.com/kafka4beam/wolff/pull/100

Handle `record_list_too_large` error returned from Kafka.
Similar to `message_too_large`  error, the batch is split, then dropped if single call is still too large.
