### PR TITLE
fix: check timer active for otp 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - '25.3'
+          - '24.3'
         kafka:
           - '2.4'
           - '1.1'

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
+* 1.5.20
+  - Fix producer reconnect timer on OTP 24.
+
 * 1.5.19
   - Handle `record_list_too_large` error returned from Kafka.
     Similar to `message_too_large`  error, the batch is split, then dropped if single call is still too large.
+
 * 1.5.18
   - Partition metadata handling.
     - Fixed an issue introduced in 1.5.15 where temporarily missing partitions in the metadata response could leave a `wolff_producer` process permanently disconnected.

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 {profiles, [
   {test, [
     {deps, [
-      {meck, "1.0.0"}
+      {meck, "0.9.2"}
     ]}
   ]}
 ]}.

--- a/src/wolff.app.src
+++ b/src/wolff.app.src
@@ -1,6 +1,6 @@
 {application, wolff,
  [{description, "Kafka's publisher"},
-  {vsn, "1.5.19"},
+  {vsn, "1.5.20"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/wolff.appup.src
+++ b/src/wolff.appup.src
@@ -1,8 +1,13 @@
 %% -*- mode: erlang -*-
-{"1.5.19",
+{"1.5.20",
   [
+    {<<"1\\.5\\.19">>,
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
+     ]},
     {<<"1\\.5\\.18">>,
      [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.1[1-7]">>,
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}
@@ -42,8 +47,13 @@
     }
   ],
   [
+    {<<"1\\.5\\.19">>,
+     [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
+     ]},
     {<<"1\\.5\\.18">>,
      [ {load_module, wolff_producer, brutal_purge, soft_purge, []}
+     , {load_module, wolff_client, brutal_purge, soft_purge, []}
      ]},
     {<<"1\\.5\\.1[1-7]">>,
      [ {load_module, wolff_client, brutal_purge, soft_purge, []}

--- a/src/wolff_client.erl
+++ b/src/wolff_client.erl
@@ -297,7 +297,7 @@ ensure_leader_connections2(#{conn_config := ConnConfig,
     {ok, {ConnPid, {Brokers, PartitionMetaList}}} ->
       ensure_leader_connections3(St, Topic, ConnPid, Brokers, PartitionMetaList);
     {error, Reason} ->
-      log_warn("Failed to get metadata\nreason: ~p", [Reason]),
+      log_warn("failed_to_get_metadata\nreason: ~p", [Reason]),
       {error, failed_to_fetch_metadata}
   end.
 

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -599,8 +599,11 @@ log_connection_down(Topic, Partition, _, Reason) ->
 
 is_timer_on(?no_timer) ->
   false;
+is_timer_on({T, Ref}) when is_integer(T), is_reference(Ref) ->
+  %% started by timer:apply_after (OTP 24)
+  erlang:monotonic_time(microsecond) < T;
 is_timer_on({_, Ref}) when is_reference(Ref) ->
-  %% started by timer:apply_after
+  %% started by timer:apply_after (OTP 25 or later)
   is_timer_on(Ref);
 is_timer_on(Ref) when is_reference(Ref) ->
   erlang:read_timer(Ref) =/= false.


### PR DESCRIPTION
Bug introduced in 1.5.18, the timer check always resulted in `false` hence always start a new timer to discover partition leader connection.
The excessive start of timer may overload the system.