### PR TITLE
fix: upgrade to kafka_protocol-4.3.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+* 4.1.8
+  - Pin kafka_protocol-4.3.4 (crc32cer-1.1.3, kafka_protocol-4.3.4).
+   Fix connection losing queued requests when scheduled SASL re-authentication is triggered.
+   If a new re-authentication happens before the connection is still processing requests
+   left-over from the previous re-authentication, the pending requests may get lost.
+   As a result, a synced produce call may timeout.
+
 * 4.1.7
   - Pin kafka_protocol-4.3.2 (crc32cer-1.1.2).
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [ {kafka_protocol, "4.3.2"}
+{deps, [ {kafka_protocol, "4.3.4"}
        , {replayq, "0.5.0"}
        , {lc, "0.3.5"}
        , {telemetry, "1.1.0"}


### PR DESCRIPTION
Fix connection losing queued requests when scheduled SASL re-authentication is triggered.
If a new re-authentication happens before the connection is still processing requests
left-over from the previous re-authentication, the pending requests may get lost.
As a result, a synced produce call may timeout.