### PR TITLE
docs: document the reconnect_delay_ms producer option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 * 4.2.0
+  - Document the existing `reconnect_delay_ms` producer option (default 2000) in
+    the `config_key`/`config_in` specs and producer docs. Behavior is unchanged.
   - Add `max_retry` producer option (default `infinity`, i.e. retry forever).
     When set to a non-negative integer, a batch that keeps getting Kafka error
     responses (e.g. `not_leader_for_partition`) is dropped once it has been

--- a/src/wolff_producer.erl
+++ b/src/wolff_producer.erl
@@ -51,6 +51,7 @@
                       drop_if_highmem |
                       max_batch_age |
                       max_retry |
+                      reconnect_delay_ms |
                       telemetry_meta_data |
                       max_partitions.
 
@@ -69,6 +70,7 @@
                        drop_if_highmem => boolean(),
                        max_batch_age => timeout(),
                        max_retry => infinity | non_neg_integer(),
+                       reconnect_delay_ms => non_neg_integer(),
                        telemetry_meta_data => map(),
                        max_partitions => pos_integer()
                       }.
@@ -87,6 +89,7 @@
                           drop_if_highmem => boolean(),
                           max_batch_age => timeout(),
                           max_retry => infinity | non_neg_integer(),
+                          reconnect_delay_ms => non_neg_integer(),
                           telemetry_meta_data => map(),
                           max_partitions => pos_integer()
                          }.
@@ -189,6 +192,12 @@
 %%    on the first error; `infinity' (the default) retries forever. Note this
 %%    counts Kafka error responses only; resends triggered purely by connection
 %%    loss are bounded by `max_batch_age', not by `max_retry'.
+%% * `reconnect_delay_ms': default 2000. Base delay in milliseconds before a
+%%    disconnected producer tries to reconnect to the partition leader. A random
+%%    jitter of 1..1000 ms is added on top so that partition workers do not all
+%%    reconnect at the same instant. The very first attempt right after a
+%%    disconnect uses no delay (reconnect immediately); the delay applies to
+%%    subsequent attempts.
 -spec start_link(wolff:client_id(), topic(), partition(), pid() | ?conn_down(any()), config_in()) ->
   {ok, pid()} | {error, any()}.
 start_link(ClientId, Topic, Partition, MaybeConnPid, Config) ->


### PR DESCRIPTION
Make the existing `reconnect_delay_ms` producer option a first-class, documented option. **No behavior change.**

## Background

`reconnect_delay_ms` is already accepted and honored by `wolff_producer`:
- Default `2000` ms (via `use_defaults`).
- Applied in `do_ensure_delayed_reconnect/2` as `reconnect_delay_ms + rand:uniform(1000)` (1..1000 ms jitter, so partition workers do not all reconnect at the same instant).
- The first reconnect attempt right after a disconnect uses no delay (immediate); the delay applies to subsequent attempts.

But it was missing from the `config_key()` / `config_in()` / `config_state()` type specs and the producer option doc comment, so it was easy to miss and dialyzer did not recognise it as a valid producer config key.

## Change

- Add `reconnect_delay_ms` to `config_key()`, `config_in()`, and `config_state()`.
- Document it in the producer options doc comment (default, jitter, first-attempt-immediate behavior).
- Changelog note (unreleased 4.2.0).

Docs/types only — no runtime code path is touched.